### PR TITLE
Tbsim with starsim v1 - version handling. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ install_requires=[
     'seaborn',
     'pytest',
 ]
+tbsim_version = version
 if tbsim_version and tbsim_version < "1.0.0":
     install_requires.append("starsim==1.0.3")
 else:


### PR DESCRIPTION
Handling version dependencies. Also, for now it assumes that Tbsim will move to version 1.0.0 once it gets migrated to starsim V 2.0 (but we can agree on another version right before the port is available).

Also, this approach is following a highlevel rules for versioning:
Version format: MAJOR.MINOR.PATCH
MAJOR version (e.g., 2.0.0) for incompatible API changes.
MINOR version (e.g., 2.1.0) for new features, but backward-compatible.
PATCH version (e.g., 2.1.1) for backward-compatible bug fixes.