### PR TITLE
71 - Run tests workflow fix

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,7 +12,9 @@ on:
       - main # This ensures the workflow runs whenever code is pushed to the main branch
     paths:
       - 'tbsim/**'
-      - '**.yml'
+      - '.github/workflows/**'
+      - 'scripts/**'
+      - 'tests/**'
 
 concurrency:
   group: ${{ github.ref }}-tests
@@ -60,19 +62,3 @@ jobs:
         with:
           name: test-results-${{ matrix.python-version }}
           path: tests/test-results.xml
-
-      - name: Archive test results in repo
-        if: always() # Ensure this step runs whether tests pass or fail
-        run: |
-          TIMESTAMP=$(date +'%Y-%m-%d_%H-%M-%S')
-          mkdir -p archived-results/${{ matrix.python-version }}
-          cp tests/test-results.xml archived-results/${{ matrix.python-version }}/test-results-$TIMESTAMP.xml
-          
-      - name: Commit and push test results archive
-        if: always() # Ensure this step runs whether tests pass or fail
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          git add archived-results/
-          git commit -m "Archive test results for Python ${{ matrix.python-version }} on $TIMESTAMP"
-          git push


### PR DESCRIPTION
Addressing issues with workflow (bug #71 )

## IMPROVEMENTS:
- Broaden the trigger scope to include pushes to the `tbsim` directory and other relevant files.
- Use concurrency management to avoid redundant runs triggered by both `push` and `pull_request` events.
- Test across multiple Python versions (e.g., 3.10 and 3.11).
- Always upload test results and archive them for future reference, regardless of whether tests pass or fail.
- Handle test failures gracefully to ensure consistent reporting and test result tracking.
