### PR TITLE
Update Dockerfile

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -17,15 +17,15 @@ USER jovyan
 WORKDIR /home/jovyan/work
 
 # Copy requirements and install Python packages
-COPY requirements.txt .
+COPY binder/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy postBuild script and make it executable
-COPY postBuild .
+COPY binder/postBuild .
 RUN chmod +x postBuild
 
 # Copy start script and make it executable
-COPY start .
+COPY binder/start .
 RUN chmod +x start
 
 # Expose port


### PR DESCRIPTION
This pull request updates file paths in the `binder/Dockerfile` to reflect a new directory structure for the `binder` folder. These changes ensure that the correct files are referenced during the Docker build process.

### Updates to file paths in `binder/Dockerfile`:
* Updated the `requirements.txt` file path to `binder/requirements.txt` for Python package installation.
* Updated the `postBuild` script file path to `binder/postBuild` and ensured it remains executable.
* Updated the `start` script file path to `binder/start` and ensured it remains executable.hot fix for binder failure: 
 > [ 9/10] COPY start .:
  ------
  Dockerfile:28
  --------------------
    26 |     
    27 |     # Copy start script and make it executable
    28 | >>> COPY start .
    29 |     RUN chmod +x start
    30 |     
  --------------------
    ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref 8d06e044-5e69-4e86-9271-2e98651254f2::p8epq969uxufb9cb3b9tnnaey: "/start": not found
    Error during build: Command '['docker', 'buildx', 'build', '--progress', 'plain', '--push', '--build-arg', 'NB_USER=jovyan', '--build-arg', 'NB_UID=1000', '--file', 'binder/Dockerfile', '--tag', 'registry.gesis.mybinder.org/i-starsimhub-2dtbsim-506c8d:ef81ba382ead1dcbe082e492b20daf323a97dcf8', '--label', 'repo2docker.version=2024.07.0+166.ge795060', '--label', 'repo2docker.repo=https://github.com/starsimhub/tbsim', '--label', 'repo2docker.ref=ef81ba382ead1dcbe082e492b20daf323a97dcf8', '--platform', 'linux/amd64', '/tmp/repo2docker947wc197']' returned non-zero exit status 1.Error in event stream: Error