### PR TITLE
Bump minimum Python version from 3.10 to 3.11

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install pandoc
         run: |

--- a/.github/workflows/run_e2e.yml
+++ b/.github/workflows/run_e2e.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - name: Checkout tbsim repository

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'run tests')
     strategy:
       matrix:
-        python-version: ['3.10', '3.11'] # Add multiple Python versions
+        python-version: ['3.11', '3.14']
 
     steps:
       - name: Checkout tbsim repository

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install pandoc
         run: |

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     keywords=["agent-based model", "simulation", "disease", "epidemiology"],
     platforms=["OS Independent"],
     classifiers=CLASSIFIERS,
+    python_requires='>=3.11',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
lifelines 0.30.0 uses datetime.UTC which requires Python 3.11+, causing ImportError on 3.10 CI runners. Update all GitHub Actions workflows and add python_requires to setup.py. Also included Python 3.14 as one of the test versions.