### PR TITLE
HealthSeekingBehavior intervention, base class, tests, and examples

### DIFF
--- a/scripts/interventions/diagnostics/run_healthSeeking_lshtm.py
+++ b/scripts/interventions/diagnostics/run_healthSeeking_lshtm.py
@@ -1,0 +1,60 @@
+import tbsim as mtb
+import starsim as ss
+import matplotlib.pyplot as plt
+import numpy as np
+
+sim = ss.Sim(
+    people=ss.People(n_agents=1000),
+    diseases=mtb.TB_LSHTM(pars={'init_prev': ss.bernoulli(0.05)}),
+    networks=ss.RandomNet(),
+    interventions=mtb.HealthSeekingBehavior(pars={
+        'initial_care_seeking_rate': ss.perday(0.1),
+        'single_use': False,
+    }),
+    pars=dict(start=ss.date(2000), stop=ss.date(2020), dt=ss.months(6)),
+)
+sim.run()
+
+tb  = sim.diseases[0].results
+hsb = sim.results.healthseekingbehavior
+t   = tb['timevec']
+
+# TB states
+fig, panel = plt.subplots(1, 2, figsize=(12, 4))
+
+for key in ['n_UNCONFIRMED', 'n_ASYMPTOMATIC', 'n_SYMPTOMATIC']:
+    if key in tb:
+        panel[0].plot(t, tb[key].values, label=key.replace('n_', ''))
+panel[0].set_title('Active TB states')
+panel[0].set_ylabel('Count')
+panel[0].legend()
+
+if 'n_infectious' in tb:
+    panel[1].plot(t, tb['n_infectious'].values, label='Infectious')
+panel[1].set_title('Infectious')
+panel[1].set_ylabel('Count')
+panel[1].legend()
+
+plt.tight_layout()
+plt.show()
+
+# Health-seeking
+t_hsb     = hsb['n_sought_care'].timevec
+n_sought  = hsb['n_sought_care'].values
+n_eligible = hsb['n_eligible'].values
+
+fig, panel = plt.subplots(1, 2, figsize=(12, 4))
+
+panel[0].plot(t_hsb, n_sought, label='Cumulative sought care')
+panel[0].plot(t_hsb, np.diff(n_sought, prepend=0), label='New per step', linestyle='--')
+panel[0].set_title('Health-seeking')
+panel[0].set_ylabel('People')
+panel[0].legend()
+
+panel[1].plot(t_hsb, n_eligible, label='Eligible (not yet sought)')
+panel[1].set_title('Eligible for care-seeking')
+panel[1].set_ylabel('People')
+panel[1].legend()
+
+plt.tight_layout()
+plt.show()

--- a/tbsim/interventions/base.py
+++ b/tbsim/interventions/base.py
@@ -1,0 +1,44 @@
+"""Base class for TB interventions.
+
+Subclass ``TBIntervention`` instead of ``ss.Intervention`` when your
+intervention needs the TB module and its disease states. It auto-detects
+the TB variant and exposes ``self.tb`` and ``self.states``. Set
+``_state_method`` (e.g. ``'care_seeking_eligible'``) to pick which states
+your intervention uses.
+"""
+
+import starsim as ss
+from tbsim.tb import TBS, TB
+from tbsim.tb_lshtm import TBSL, TB_LSHTM, TB_LSHTM_Acute
+
+__all__ = ['TBIntervention']
+
+# Maps each TB disease class to the enum that defines its states.
+# When a new TB variant is added to tbsim, add a corresponding entry here.
+_DISEASE_ENUM = {
+    TB_LSHTM_Acute: TBSL,
+    TB_LSHTM:       TBSL,
+    TB:             TBS,
+}
+
+
+class TBIntervention(ss.Intervention):
+    """Base for interventions that need the TB module and its disease states.
+
+    Provides ``self.tb`` (the TB disease module), ``self.state_enum`` (TBS or
+    TBSL), and ``self.states`` (if ``_state_method`` is set).
+    """
+
+    _state_method = None
+
+    def init_post(self):
+        """Detect the TB variant in the simulation and resolve the state enum
+        and (if ``_state_method`` is set) the relevant disease states."""
+        super().init_post()
+        self.tb = getattr(self.sim.diseases, 'tb', None) or self.sim.diseases[0]
+        for cls in type(self.tb).__mro__:
+            if cls in _DISEASE_ENUM:
+                self.state_enum = _DISEASE_ENUM[cls]
+                break
+        if self._state_method is not None:
+            self.states = getattr(self.state_enum, self._state_method)()

--- a/tbsim/interventions/healthseeking.py
+++ b/tbsim/interventions/healthseeking.py
@@ -1,0 +1,115 @@
+import numpy as np
+import starsim as ss
+from tbsim.interventions.base import TBIntervention
+
+__all__ = ['HealthSeekingBehavior']
+
+#TODO: what is the best way to handle elegibility for care-seeking? 
+# maybe we should allow the researcher to specify the symptoms and let the
+# intervention handle the identification of eligible agents?
+
+class HealthSeekingBehavior(TBIntervention):
+    """TB intervention modeling when symptomatic agents seek care.
+
+    Identifies agents eligible for care-seeking (based on TB state) and
+    samples who seeks care each step. Does not initiate treatment;
+    care-seeking agents become available for diagnostic intervention
+    (e.g. TBDiagnostic).
+    """
+
+    _state_method = 'care_seeking_eligible'
+
+    def __init__(self, pars=None, **kwargs):
+        """Initialize the intervention with care-seeking probability."""
+        super().__init__(**kwargs)
+        self.define_pars(
+            prob=0.1,
+            initial_care_seeking_rate=None,
+            single_use=True,
+            start=None,
+            stop=None,
+        )
+        self.update_pars(pars=pars, **kwargs)
+        self.define_states(
+            ss.BoolArr('sought_care'),
+        )
+        self._new_seekers_count = 0
+        self._care_seeking_dist = None
+
+    def init_post(self):
+        """Validate parameters and build the care-seeking sampling distribution.
+
+        Called automatically after the simulation is initialised.
+        If ``initial_care_seeking_rate`` is set, it is validated here and
+        converted to a probability each step. Otherwise a Bernoulli
+        distribution is created from ``prob`` and reused every step.
+        """
+        super().init_post()
+
+        rate = self.pars.initial_care_seeking_rate
+        if rate is not None:
+            if not isinstance(rate, ss.Rate):
+                raise TypeError(
+                    f"initial_care_seeking_rate must be an ss.Rate (e.g. ss.perday(0.1), ss.peryear(0.1)), got {type(rate).__name__}"
+                )
+            return
+        trace = self.name or 'HealthSeekingBehavior.care_seeking'
+        if isinstance(self.pars.prob, ss.Dist):
+            dist = self.pars.prob
+        else:
+            dist = ss.bernoulli(p=self.pars.prob)
+        dist.init(trace=trace, sim=self.sim, module=self)
+        self._care_seeking_dist = dist
+
+    def step(self):
+        """Identify eligible agents and sample who seeks care this step."""
+        sim = self.sim
+        t = sim.now
+        if self.pars.start is not None and t < self.pars.start:
+            return
+        if self.pars.stop is not None and t > self.pars.stop:
+            return
+
+        active_uids = np.where(np.isin(self.tb.state, self.states))[0]
+        not_yet_sought = active_uids[~self.sought_care[active_uids]]
+        self._new_seekers_count = 0
+
+        if len(not_yet_sought) == 0:
+            return
+
+        if self.pars.initial_care_seeking_rate is not None:
+            rate = self.pars.initial_care_seeking_rate
+            if not isinstance(rate, ss.Rate):
+                raise TypeError(
+                    f"initial_care_seeking_rate must be an ss.Rate (e.g. ss.perday(0.1)), got {type(rate).__name__}"
+                )
+            p = rate.to_prob()
+            dist = ss.bernoulli(p=p)
+            trace = self.name or 'HealthSeekingBehavior.care_seeking'
+            dist.init(trace=trace, sim=sim, module=self)
+            seeking_uids = dist.filter(not_yet_sought)
+        else:
+            seeking_uids = self._care_seeking_dist.filter(not_yet_sought)
+
+        if len(seeking_uids) == 0:
+            return
+        self._new_seekers_count = len(seeking_uids)
+        self.sought_care[seeking_uids] = True
+        if self.pars.single_use:
+            self.expired = True
+
+    def init_results(self):
+        super().init_results()
+        self.define_results(
+            ss.Result('new_sought_care', dtype=int),
+            ss.Result('n_sought_care', dtype=int),
+            ss.Result('n_eligible', dtype=int),
+        )
+
+    def update_results(self):
+        """Record care-seeking counts and remaining eligible agents."""
+        self.results['new_sought_care'][self.ti] = self._new_seekers_count
+        self.results['n_sought_care'][self.ti] = np.count_nonzero(self.sought_care)
+        active_uids = np.where(np.isin(self.tb.state, self.states))[0]
+        not_yet_sought = active_uids[~self.sought_care[active_uids]]
+        self.results['n_eligible'][self.ti] = len(not_yet_sought)

--- a/tests/test_healthseeking_behavior.py
+++ b/tests/test_healthseeking_behavior.py
@@ -1,0 +1,492 @@
+"""
+Tests for HealthSeekingBehavior intervention with TB_LSHTM and legacy TB model (tbsim.tb.TB).
+
+Covers: integration run, eligibility (SYMPTOMATIC only for LSHTM; ACTIVE_SMPOS/SMNEG/EXPTB for TB),
+prob vs initial_care_seeking_rate, single_use, start/stop, parameter validation, results consistency.
+"""
+
+import pytest
+import numpy as np
+import starsim as ss
+import tbsim as mtb
+from tbsim import TB_LSHTM, TB, TBSL, TBS
+from tbsim.interventions.healthseeking import HealthSeekingBehavior
+
+
+def make_sim_with_hsb(
+    agents=200,
+    start=ss.date("2000-01-01"),
+    stop=ss.date("2005-12-31"),
+    dt=ss.days(7),
+    tb_pars=None,
+    hsb_pars=None,
+):
+    """Sim with TB_LSHTM and one HealthSeekingBehavior intervention."""
+    pop = ss.People(n_agents=agents)
+    tb = mtb.TB_LSHTM(pars=tb_pars or {})
+    net = ss.RandomNet(pars=dict(n_contacts=ss.poisson(lam=5), dur=0))
+    hsb = HealthSeekingBehavior(pars=hsb_pars or {})
+    sim = ss.Sim(
+        people=pop,
+        networks=net,
+        diseases=tb,
+        interventions=[hsb],
+        pars=dict(dt=dt, start=start, stop=stop),
+    )
+    sim.pars.verbose = 0
+    return sim
+
+
+def make_sim_with_hsb_tb(
+    agents=200,
+    start=ss.date("2000-01-01"),
+    stop=ss.date("2005-12-31"),
+    dt=ss.days(7),
+    tb_pars=None,
+    hsb_pars=None,
+):
+    """Sim with legacy TB model and one HealthSeekingBehavior intervention."""
+    pop = ss.People(n_agents=agents)
+    tb = mtb.TB(pars=tb_pars or {})
+    net = ss.RandomNet(pars=dict(n_contacts=ss.poisson(lam=5), dur=0))
+    hsb = HealthSeekingBehavior(pars=hsb_pars or {})
+    sim = ss.Sim(
+        people=pop,
+        networks=net,
+        diseases=tb,
+        interventions=[hsb],
+        pars=dict(dt=dt, start=start, stop=stop),
+    )
+    sim.pars.verbose = 0
+    return sim
+
+
+def get_hsb(sim):
+    """Return the HealthSeekingBehavior intervention from a sim (after init or run)."""
+    # Starsim stores interventions in an ndict keyed by lowercase module name
+    key = "healthseekingbehavior"
+    if key in sim.interventions:
+        return sim.interventions[key]
+    for m in sim.interventions.values():
+        if isinstance(m, HealthSeekingBehavior):
+            return m
+    raise LookupError("HealthSeekingBehavior not found in sim.interventions")
+
+
+# --- Integration: sim runs (TB_LSHTM) ---
+
+
+def test_tb_lshtm_healthseeking_sim_runs():
+    """TB_LSHTM + HealthSeekingBehavior(prob) runs without error."""
+    sim = make_sim_with_hsb(
+        agents=150,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2002-12-31"),
+        hsb_pars=dict(prob=0.1, single_use=False),
+    )
+    sim.run()
+    tb = sim.diseases[0]
+    assert "n_infectious" in tb.results
+    hsb = get_hsb(sim)
+    assert "new_sought_care" in hsb.results
+    assert "n_sought_care" in hsb.results
+    assert "n_eligible" in hsb.results
+
+
+def test_tb_lshtm_healthseeking_with_rate_runs():
+    """TB_LSHTM + HealthSeekingBehavior(initial_care_seeking_rate) runs."""
+    sim = make_sim_with_hsb(
+        agents=100,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2001-12-31"),
+        hsb_pars=dict(
+            initial_care_seeking_rate=ss.peryear(2.0),
+            single_use=False,
+        ),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    assert hsb.results["n_sought_care"] is not None
+    # Cumulative should be non-decreasing
+    n_sought = np.asarray(hsb.results["n_sought_care"][:])
+    assert np.all(np.diff(n_sought) >= 0)
+
+
+# --- Eligibility: LSHTM uses SYMPTOMATIC only ---
+
+
+def test_healthseeking_eligible_states_lshtm():
+    """With TB_LSHTM, care-seeking-eligible states are SYMPTOMATIC only."""
+    sim = make_sim_with_hsb(agents=50)
+    sim.init()
+    hsb = get_hsb(sim)
+    expected = TBSL.care_seeking_eligible()
+    assert np.array_equal(hsb.states, expected)
+    assert list(hsb.states) == [TBSL.SYMPTOMATIC]
+    assert hsb.tb is sim.diseases[0]
+
+
+def test_healthseeking_only_symptomatic_eligible():
+    """Only agents in SYMPTOMATIC are counted as eligible; ASYMPTOMATIC are not."""
+    sim = make_sim_with_hsb(agents=80, hsb_pars=dict(prob=1.0, single_use=False))
+    sim.init()
+    tb = sim.diseases[0]
+    hsb = get_hsb(sim)
+    # Set 4 agents to SYMPTOMATIC, 3 to ASYMPTOMATIC; rest stay SUSCEPTIBLE
+    uids_sym = np.array([0, 1, 2, 3])
+    uids_asy = np.array([4, 5, 6])
+    tb.state[uids_sym] = TBSL.SYMPTOMATIC
+    tb.state[uids_asy] = TBSL.ASYMPTOMATIC
+    tb.susceptible[uids_sym] = False
+    tb.susceptible[uids_asy] = False
+    tb.infected[uids_sym] = True
+    tb.infected[uids_asy] = True
+    tb.ti_next[uids_sym] = np.inf
+    tb.ti_next[uids_asy] = np.inf
+    # Ensure intervention sees current state
+    active_uids = np.where(np.isin(tb.state, hsb.states))[0]
+    assert len(active_uids) == 4
+    assert set(active_uids) == set(uids_sym)
+    # With prob=1.0, all 4 should seek care in one step
+    hsb.step()
+    assert np.sum(hsb.sought_care[uids_sym]) == 4
+    assert np.sum(hsb.sought_care[uids_asy]) == 0
+
+
+# --- prob-based care-seeking ---
+
+
+def test_healthseeking_prob_one_all_eligible_seek():
+    """With prob=1.0, all currently eligible (and not yet sought) seek in one step."""
+    sim = make_sim_with_hsb(
+        agents=60,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2000-02-01"),
+        hsb_pars=dict(prob=1.0, single_use=False),
+    )
+    sim.init()
+    tb = sim.diseases[0]
+    hsb = get_hsb(sim)
+    uids_sym = np.array([10, 11, 12])
+    tb.state[uids_sym] = TBSL.SYMPTOMATIC
+    tb.susceptible[uids_sym] = False
+    tb.infected[uids_sym] = True
+    tb.ti_next[uids_sym] = np.inf
+    hsb.step()
+    assert hsb._new_seekers_count == 3
+    assert np.all(hsb.sought_care[uids_sym])
+
+
+def test_healthseeking_prob_zero_none_seek():
+    """With prob=0.0, no one seeks care."""
+    sim = make_sim_with_hsb(
+        agents=60,
+        hsb_pars=dict(prob=0.0, single_use=False),
+    )
+    sim.init()
+    tb = sim.diseases[0]
+    hsb = get_hsb(sim)
+    uids_sym = np.array([0, 1, 2])
+    tb.state[uids_sym] = TBSL.SYMPTOMATIC
+    tb.susceptible[uids_sym] = False
+    tb.infected[uids_sym] = True
+    tb.ti_next[uids_sym] = np.inf
+    hsb.step()
+    assert hsb._new_seekers_count == 0
+    assert not hsb.sought_care[uids_sym].any()
+
+
+# --- initial_care_seeking_rate ---
+
+
+def test_healthseeking_initial_care_seeking_rate_peryear():
+    """initial_care_seeking_rate with ss.peryear runs and converts to per-step prob."""
+    sim = make_sim_with_hsb(
+        agents=100,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2003-12-31"),
+        hsb_pars=dict(
+            initial_care_seeking_rate=ss.peryear(1.0),
+            single_use=False,
+        ),
+    )
+    sim.init()
+    hsb = get_hsb(sim)
+    assert hsb.pars.initial_care_seeking_rate is not None
+    assert hsb._care_seeking_dist is None  # rate path uses inline dist in step
+    sim.run()
+    assert np.any(np.asarray(hsb.results["new_sought_care"][:]) >= 0)
+
+
+def test_healthseeking_initial_care_seeking_rate_perday():
+    """initial_care_seeking_rate with ss.perday runs."""
+    sim = make_sim_with_hsb(
+        agents=80,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2001-06-30"),
+        dt=ss.days(7),
+        hsb_pars=dict(
+            initial_care_seeking_rate=ss.perday(0.01),
+            single_use=False,
+        ),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    n_sought = np.asarray(hsb.results["n_sought_care"][:])
+    assert len(n_sought) > 0
+    assert np.all(n_sought >= 0)
+
+
+# --- single_use ---
+
+
+def test_healthseeking_single_use_expires_after_first_seekers():
+    """With single_use=True, intervention expires after first step with any seekers."""
+    sim = make_sim_with_hsb(
+        agents=50,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2002-12-31"),
+        hsb_pars=dict(prob=0.5, single_use=True),
+    )
+    sim.init()
+    hsb = get_hsb(sim)
+    assert not getattr(hsb, "expired", False)
+    # Force some eligible and run steps until someone seeks (prob=0.5 may need a few steps)
+    tb = sim.diseases[0]
+    uids_sym = np.array([0, 1, 2, 3, 4])
+    tb.state[uids_sym] = TBSL.SYMPTOMATIC
+    tb.susceptible[uids_sym] = False
+    tb.infected[uids_sym] = True
+    tb.ti_next[uids_sym] = np.inf
+    for _ in range(20):
+        hsb.step()
+        if getattr(hsb, "expired", False):
+            break
+    assert getattr(hsb, "expired", False), "single_use=True should set expired after first seekers"
+
+
+def test_healthseeking_single_use_false_multiple_steps_seek():
+    """With single_use=False, new_sought_care can be non-zero in multiple steps."""
+    sim = make_sim_with_hsb(
+        agents=200,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2004-12-31"),
+        tb_pars=dict(init_prev=ss.bernoulli(0.05), beta=ss.peryear(0.25)),
+        hsb_pars=dict(prob=0.2, single_use=False),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    assert not getattr(hsb, "expired", False)
+    new_sought = np.asarray(hsb.results["new_sought_care"][:])
+    steps_with_seekers = np.sum(new_sought > 0)
+    assert steps_with_seekers >= 0  # may be 0 if no one became symptomatic
+    # Cumulative can grow over time when single_use=False
+    n_sought = np.asarray(hsb.results["n_sought_care"][:])
+    assert np.all(np.diff(n_sought) >= 0)
+
+
+# --- start / stop ---
+
+
+def test_healthseeking_start_after_start_date():
+    """Intervention does nothing before pars.start."""
+    sim = make_sim_with_hsb(
+        agents=50,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2005-12-31"),
+        hsb_pars=dict(prob=1.0, single_use=False, start=ss.date("2002-01-01")),
+    )
+    sim.init()
+    tb = sim.diseases[0]
+    hsb = get_hsb(sim)
+    uids_sym = np.array([0, 1, 2])
+    tb.state[uids_sym] = TBSL.SYMPTOMATIC
+    tb.susceptible[uids_sym] = False
+    tb.infected[uids_sym] = True
+    tb.ti_next[uids_sym] = np.inf
+    # Sim time is 2000-01-01; start is 2002 -> step should return without setting sought_care
+    assert sim.now < hsb.pars.start
+    hsb.step()
+    assert hsb._new_seekers_count == 0
+    assert not hsb.sought_care[uids_sym].any()
+
+
+def test_healthseeking_stop_before_stop_date():
+    """Intervention inactive after pars.stop (when sim runs past stop)."""
+    sim = make_sim_with_hsb(
+        agents=80,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2005-12-31"),
+        hsb_pars=dict(prob=0.3, single_use=False, stop=ss.date("2001-06-01")),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    # Results should exist; we only check that run completed
+    assert "n_eligible" in hsb.results
+
+
+# --- Parameter validation ---
+
+
+def test_healthseeking_invalid_initial_care_seeking_rate_raises():
+    """initial_care_seeking_rate must be ss.Rate; float raises TypeError in init_post."""
+    sim = make_sim_with_hsb(
+        agents=30,
+        hsb_pars=dict(initial_care_seeking_rate=0.5),
+    )
+    with pytest.raises(TypeError) as exc_info:
+        sim.init()
+    assert "initial_care_seeking_rate" in str(exc_info.value)
+    assert "ss.Rate" in str(exc_info.value)
+
+
+# --- Results consistency ---
+
+
+def test_healthseeking_results_new_sought_care_cumulative_consistent():
+    """new_sought_care and n_sought_care are consistent: n_sought_care is cumulative of new_sought_care."""
+    sim = make_sim_with_hsb(
+        agents=100,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2002-12-31"),
+        hsb_pars=dict(prob=0.15, single_use=False),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    new_sought = np.asarray(hsb.results["new_sought_care"][:])
+    n_sought = np.asarray(hsb.results["n_sought_care"][:])
+    assert len(new_sought) == len(n_sought)
+    np.testing.assert_array_equal(np.cumsum(new_sought), n_sought)
+
+
+def test_healthseeking_results_n_eligible_non_negative():
+    """n_eligible is non-negative at every time step."""
+    sim = make_sim_with_hsb(
+        agents=80,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2003-12-31"),
+        hsb_pars=dict(prob=0.1, single_use=False),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    n_eligible = np.asarray(hsb.results["n_eligible"][:])
+    assert np.all(n_eligible >= 0)
+
+
+def test_healthseeking_results_n_eligible_plus_sought_le_eligible_states():
+    """At each step, n_eligible + (agents who sought from current eligible pool) is bounded by count in eligible state."""
+    sim = make_sim_with_hsb(
+        agents=120,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2002-12-31"),
+        hsb_pars=dict(prob=0.2, single_use=False),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    n_eligible = np.asarray(hsb.results["n_eligible"][:])
+    n_sought = np.asarray(hsb.results["n_sought_care"][:])
+    new_sought = np.asarray(hsb.results["new_sought_care"][:])
+    # n_eligible[t] = number eligible at t who have not yet sought
+    # So n_eligible[t] + new_sought[t] <= (number in SYMPTOMATIC at that step) in principle;
+    # we only check n_eligible and new_sought are non-negative and n_sought is cumulative
+    assert np.all(n_eligible >= 0)
+    assert np.all(new_sought >= 0)
+    assert np.all(np.diff(n_sought) == new_sought[1:])
+
+
+# =============================================================================
+# HealthSeekingBehavior with legacy TB model (tbsim.tb.TB)
+# =============================================================================
+# Care-seeking-eligible states: ACTIVE_SMPOS, ACTIVE_SMNEG, ACTIVE_EXPTB (excludes ACTIVE_PRESYMP).
+
+
+def test_tb_healthseeking_sim_runs():
+    """Legacy TB + HealthSeekingBehavior(prob) runs without error."""
+    sim = make_sim_with_hsb_tb(
+        agents=150,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2002-12-31"),
+        hsb_pars=dict(prob=0.1, single_use=False),
+    )
+    sim.run()
+    tb = sim.diseases[0]
+    assert "n_infectious" in tb.results
+    hsb = get_hsb(sim)
+    assert "new_sought_care" in hsb.results
+    assert "n_sought_care" in hsb.results
+    assert "n_eligible" in hsb.results
+
+
+def test_tb_healthseeking_with_rate_runs():
+    """Legacy TB + HealthSeekingBehavior(initial_care_seeking_rate) runs."""
+    sim = make_sim_with_hsb_tb(
+        agents=100,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2001-12-31"),
+        hsb_pars=dict(
+            initial_care_seeking_rate=ss.peryear(1.5),
+            single_use=False,
+        ),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    n_sought = np.asarray(hsb.results["n_sought_care"][:])
+    assert len(n_sought) > 0
+    assert np.all(np.diff(n_sought) >= 0)
+
+
+def test_tb_healthseeking_eligible_states():
+    """With legacy TB, care-seeking-eligible states are ACTIVE_SMPOS, ACTIVE_SMNEG, ACTIVE_EXPTB only."""
+    sim = make_sim_with_hsb_tb(agents=50)
+    sim.init()
+    hsb = get_hsb(sim)
+    expected = TBS.care_seeking_eligible()
+    assert np.array_equal(np.sort(hsb.states), np.sort(expected))
+    assert set(hsb.states) == {TBS.ACTIVE_SMPOS, TBS.ACTIVE_SMNEG, TBS.ACTIVE_EXPTB}
+    assert TBS.ACTIVE_PRESYMP not in hsb.states
+    assert hsb.tb is sim.diseases[0]
+
+
+def test_tb_healthseeking_only_symptomatic_active_eligible():
+    """Only ACTIVE_SMPOS, ACTIVE_SMNEG, ACTIVE_EXPTB are eligible; ACTIVE_PRESYMP is not."""
+    sim = make_sim_with_hsb_tb(agents=80, hsb_pars=dict(prob=1.0, single_use=False))
+    sim.init()
+    tb = sim.diseases[0]
+    hsb = get_hsb(sim)
+    uids_eligible = np.array([0, 1, 2])
+    uids_presymp = np.array([3, 4])
+    tb.state[uids_eligible] = TBS.ACTIVE_SMPOS
+    tb.state[uids_presymp] = TBS.ACTIVE_PRESYMP
+    hsb.step()
+    assert np.sum(hsb.sought_care[uids_eligible]) == 3
+    assert np.sum(hsb.sought_care[uids_presymp]) == 0
+
+
+def test_tb_healthseeking_all_three_active_states_eligible():
+    """ACTIVE_SMPOS, ACTIVE_SMNEG, and ACTIVE_EXPTB are all care-seeking-eligible."""
+    sim = make_sim_with_hsb_tb(agents=60, hsb_pars=dict(prob=1.0, single_use=False))
+    sim.init()
+    tb = sim.diseases[0]
+    hsb = get_hsb(sim)
+    tb.state[0] = TBS.ACTIVE_SMPOS
+    tb.state[1] = TBS.ACTIVE_SMNEG
+    tb.state[2] = TBS.ACTIVE_EXPTB
+    hsb.step()
+    assert hsb.sought_care[0] and hsb.sought_care[1] and hsb.sought_care[2]
+    assert hsb._new_seekers_count == 3
+
+
+def test_tb_healthseeking_results_consistent():
+    """With legacy TB, new_sought_care and n_sought_care are cumulative-consistent."""
+    sim = make_sim_with_hsb_tb(
+        agents=80,
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2002-12-31"),
+        hsb_pars=dict(prob=0.15, single_use=False),
+    )
+    sim.run()
+    hsb = get_hsb(sim)
+    new_sought = np.asarray(hsb.results["new_sought_care"][:])
+    n_sought = np.asarray(hsb.results["n_sought_care"][:])
+    assert len(new_sought) == len(n_sought)
+    np.testing.assert_array_equal(np.cumsum(new_sought), n_sought)


### PR DESCRIPTION
This pull request introduces a new, modular base class for TB interventions and implements a refactored `HealthSeekingBehavior` intervention. It also updates and simplifies the example scripts for running and visualizing health-seeking behavior simulations, including support for different TB models and clearer plotting. The changes improve code maintainability, usability, and clarity for both intervention development and simulation analysis.

## New:
### TB intervention framework:

* Added `TBIntervention` base class in `tbsim/interventions/base.py` to provide automatic detection of TB model variants and expose relevant disease states for interventions, improving modularity and ease of extension.

### Health-seeking intervention refactor:

* Rewrote `HealthSeekingBehavior` in `tbsim/interventions/healthseeking.py` to inherit from `TBIntervention`, handle eligibility and care-seeking sampling more robustly, and record new/cumulative care-seeking and eligibility metrics.


* test and sample scripts. 