### PR TITLE
Refactor TPT to product-based approach, extract shared TBProductRoutine

### DIFF
--- a/tbsim/interventions/__init__.py
+++ b/tbsim/interventions/__init__.py
@@ -5,21 +5,21 @@ This module contains all intervention classes for the TB simulation.
 """
 
 # Import all intervention classes
-from .interventions import *
+from .interventions import TBProductRoutine
 from .beta import *
-from .tpt import TPTInitiation
+from .tpt import TPTTx, TPTSimple
 from .bcg import BCGVx, BCGRoutine
 from .tb_treatment import TBTreatment, EnhancedTBTreatment, create_dots_treatment, create_dots_improved_treatment, create_first_line_treatment
 from .tb_drug_types import TBDrugType, TBDrugParameters, TBDrugTypeParameters, get_dots_parameters, get_drug_parameters, get_all_drug_parameters
 from .tb_health_seeking import HealthSeekingBehavior
 from .tb_diagnostic import TBDiagnostic, EnhancedTBDiagnostic
-from .interventions import TBVaccinationCampaign
 
 # Export all classes
 __all__ = [
+    'TBProductRoutine',
     'BetaByYear',
-    'Product',
-    'TPTInitiation',
+    'TPTTx',
+    'TPTSimple',
     'BCGVx',
     'BCGRoutine',
     'TBTreatment',
@@ -36,5 +36,4 @@ __all__ = [
     'HealthSeekingBehavior',
     'TBDiagnostic',
     'EnhancedTBDiagnostic',
-    'TBVaccinationCampaign',
 ]

--- a/tbsim/interventions/interventions.py
+++ b/tbsim/interventions/interventions.py
@@ -1,113 +1,127 @@
-import starsim as ss
-import sciris as sc
+"""
+Shared intervention infrastructure for TBsim.
+
+``TBProductRoutine`` — generic routine delivery for TB vaccine/treatment products.
+"""
+
 import numpy as np
-from tbsim import TBS
-import datetime as dt
-import tbsim
-import pandas as pd
+import starsim as ss
 
-__all__ = ['Product', 'TBVaccinationCampaign', 'get_extrastates']
+__all__ = ['TBProductRoutine']
 
 
-def get_extrastates():
-    exs = [ss.BoolState('sought_care', default=False),
-        ss.FloatArr('care_seeking_multiplier', default=1.0),
-        ss.BoolState('multiplier_applied', default=False),
-        ss.FloatArr('n_times_tested', default=0.0),
-        ss.FloatArr('n_times_treated', default=0.0),
-        ss.BoolState('returned_to_community', default=False),
-        ss.BoolState('received_tpt', default=False),
-        ss.BoolState('tb_treatment_success', default=False),
-        ss.BoolState('tested', default=False),
-        ss.BoolState('test_result', default=False),
-        ss.BoolState('diagnosed', default=False),
-        ss.BoolState('on_tpt', default=True),
-        ss.BoolState('tb_smear', default=False),
-        ss.BoolState('hiv_positive', default=False),
-        ss.BoolState('eptb', default=False),
-        ss.BoolState('symptomatic', default=False),
-        ss.BoolState('presymptomatic', default=False),
-        ss.BoolState('non_symptomatic', default=True),
-        ss.BoolState('screen_negative', default=True),
-        ss.BoolState('household_contact', default=False),
-        ss.BoolState('treatment_success', default=False),
-        ss.BoolState('treatment_failure', default=False),
-        ss.IntArr('hhid', default=-1),
-        ss.FloatArr('vaccination_year', default=np.nan),]
-    return exs
-   
-
-class Product(ss.Module):
+class TBProductRoutine(ss.Intervention):
     """
-    Class to define a vaccine product with specific attributes.
-    """
-    def __init__(self, name, efficacy, doses):
-        self.name = name
-        self.efficacy = efficacy
-        self.doses = doses
-        
-    def init_pre(self, sim):
-        if not self.initialized:
-            super().init_pre(sim)
-        else:
-            return
-    def __repr__(self):
-        return f"Product(name={self.name}, efficacy={self.efficacy}, doses={self.doses})"
-    
-    def administer(self, people, inds):
-        """ Adminster a Product - implemented by derived classes """
-        print("vaccine administered to people")
-        
-        return
+    Generic routine delivery for TB vaccine/treatment products.
 
-class TBVaccinationCampaign(ss.Intervention):
-    """
-    Base class for any intervention that uses campaign delivery; handles interpolation of input years.
+    Handles date-windowed delivery with composable eligibility filters
+    (age range, disease state, user-provided callable) and orchestrates
+    per-step product operations.
+
+    Any product that exposes ``update_roster()``, ``administer(people, uids)``,
+    and ``apply_protection()`` can be plugged into this delivery.
+
+    Parameters
+    ----------
+    product : ss.Vx
+        The vaccine/treatment product.
+    coverage : ss.bernoulli
+        Fraction of eligible individuals who accept (applied once per person).
+    start / stop : ss.date
+        Campaign window.
+    age_range : list or None
+        ``[min_age, max_age]`` filter, or ``None`` to skip.
+    eligible_states : list or None
+        List of disease-state values (e.g. ``[TBSL.INFECTION]``) to filter on,
+        or ``None`` to skip.
+    eligibility : callable or None
+        User-provided ``fn(sim) → BoolArr | uids`` for custom filtering
+        (passed through to ``ss.Intervention``).
     """
 
-    def __init__(self, year=1900, product=None, rate =.015, target_gender='All', target_age=10, target_state=None, new_value_fraction=1, prob=None, *args, **kwargs):
-        if product is None:
-            raise NotImplementedError('No product specified')
-        self.year = sc.promotetoarray(year)
-        self.rate = sc.promotetoarray(rate)
-        self.target_gender = target_gender
-        self.target_age = target_age
-        self.prob = sc.promotetoarray(prob)
+    def __init__(self, product=None, pars=None, **kwargs):
+        super().__init__(**kwargs)
+
+        self.define_pars(
+            start=ss.date('1900-01-01'),
+            stop=ss.date('2100-12-31'),
+            coverage=ss.bernoulli(p=0.5),
+            age_range=None,
+            eligible_states=None,
+        )
+        self.update_pars(pars)
+
         self.product = product
-        self.target_state = target_state
-        self.new_value_fraction = new_value_fraction
-        super().__init__(*args, **kwargs)
-        self.p = ss.bernoulli(p=lambda self, sim, uids: np.interp(sim.year, self.year, self.rate*sim.dt))
-        return
 
-    def init_pre(self, sim):
-        super().init_pre(sim)
-        return
-    
-    def update(self, sim):
-        if sim.year < self.year[0]:
+        self.define_states(
+            ss.BoolArr('offered', default=False),
+            ss.BoolArr('initiated', default=False),
+            ss.FloatArr('ti_initiated'),
+        )
+
+    def check_eligibility(self):
+        """
+        Combine built-in filters (age, disease state) with optional
+        user-provided eligibility callable. Coverage applied once per person.
+        """
+        # Start with Starsim's eligibility callable (or all agents)
+        eligible = super().check_eligibility()
+
+        # Age filter
+        if self.pars.age_range is not None:
+            min_age, max_age = self.pars.age_range[0], self.pars.age_range[1]
+            age_ok = (self.sim.people.age >= min_age) & (self.sim.people.age <= max_age)
+            eligible = eligible.intersect(age_ok.uids)
+
+        # Disease state filter
+        if self.pars.eligible_states is not None:
+            tb = self.sim.diseases[self.product.pars.disease]
+            state_ok = np.isin(np.asarray(tb.state[eligible]), self.pars.eligible_states)
+            eligible = eligible[state_ok]
+
+        # Not yet offered (one-time offer)
+        eligible = eligible.intersect((~self.offered).uids)
+        self.offered[eligible] = True
+
+        # Coverage filter
+        return self.pars.coverage.filter(eligible)
+
+    def step(self):
+        """
+        Routine delivery step:
+
+        1. Check date window.
+        2. Product handles internal phase transitions (``update_roster``).
+        3. Find and deliver to newly eligible agents.
+        4. Product applies ``rr_*`` modifiers for all currently protected.
+        """
+        now = self.sim.now
+        now_date = now.date() if hasattr(now, 'date') else now
+        if now_date < self.pars.start.date() or now_date > self.pars.stop.date():
             return
-        if self.product is None:
-            raise NotImplementedError('No product specified')
 
-        tb = sim.diseases['tb']
-        ppl = sim.people
-        
-        # eligible = (tb.state == self.target_state) & ppl.alive & (ppl.age >= self.target_age) & (ppl.gender == self.target_gender)
-        eligible = (tb.state == self.target_state) & ppl.alive
-        
-        eligible_uids = eligible.uids
-        
-        change_uids = self.p.filter(eligible_uids)
-        
-        # TODO: Add the actual value of the product's effectiveness here...
-        tb.rel_LS_prog[change_uids] = tb.rel_LS_prog[change_uids]*0.9 # *self.product.efficacy   
-        tb.rel_LF_prog[change_uids] = tb.rel_LF_prog[change_uids]*0.9  # *self.product.efficacy   
-        
-        return len(change_uids)
+        # Product-internal transitions (expire protection, complete treatment, etc.)
+        self.product.update_roster()
 
-# Sample calling function below
-if __name__ == '__main__':
+        # Deliver to newly eligible
+        eligible = self.check_eligibility()
+        if len(eligible) > 0:
+            self.initiated[eligible] = True
+            self.ti_initiated[eligible] = self.ti
+            self.product.administer(self.sim.people, eligible)
 
-    print('care_seeking_multiplier' in [s.name for s in tbsim.get_extrastates()])
-    print('n_times_tested' in [s.name for s in tbsim.get_extrastates()])
+        # Apply modifiers for all currently protected
+        self.product.apply_protection()
+
+    def init_results(self):
+        super().init_results()
+        if hasattr(self, 'results') and 'n_newly_initiated' in self.results:
+            return
+        self.define_results(
+            ss.Result('n_newly_initiated', dtype=int),
+            ss.Result('n_protected', dtype=int),
+        )
+
+    def update_results(self):
+        newly_initiated = np.sum((self.ti_initiated == self.ti) & self.initiated)
+        self.results['n_newly_initiated'][self.ti] = newly_initiated

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -1,225 +1,159 @@
+"""
+Tuberculosis Preventive Therapy (TPT): Product + Delivery.
+
+``TPTTx``      — treatment product  (biological effect, per-agent state)
+``TPTSimple``  — simple delivery    (targets latently infected by default)
+``TPTRegimes`` — CDC 2024 regimen duration constants
+"""
+
 import numpy as np
 import starsim as ss
-import tbsim
-from collections import namedtuple
-from enum import Enum
 
-__all__ = ['TPTInitiation', 'TPTRegimes']
+from .interventions import TBProductRoutine
+from ..tb_lshtm import TBSL
 
-class TPTInitiation(ss.Intervention):
+__all__ = ['TPTTx', 'TPTSimple']
+
+
+# ---------------------------------------------------------------------------
+# Product
+# ---------------------------------------------------------------------------
+
+class TPTTx(ss.Product):
     """
-    Tuberculosis Preventive Therapy (TPT) intervention for household contacts of care-seeking individuals.
+    TPT treatment product.
 
-    This intervention identifies households where at least one member sought care, and offers TPT to all
-    other members of those households who meet the following eligibility criteria:
-    
-    Requirements:
-        - Must have been in a previous intervention which updates sought_care, non_symptomatic, and symptomatic attributes
-    
-    Eligibility criteria:
-        - Must reside in a household where at least one member sought care
-        - Must not have symptoms (non_symptomatic = True and symptomatic = False)
-        - Must not have active TB (not in ACTIVE_PRESYMP, ACTIVE_SMPOS, ACTIVE_SMNEG, or ACTIVE_EXPTB states)
-        - Must not already be on TB treatment themselves
-        - Must be within the specified age_range (list: [min_age, max_age], default: [0, 100])
-        - Must meet HIV status threshold (if set and hiv_positive attribute present)
-    
-    Treatment logic:
-        - A Bernoulli trial (`p_tpt`) is used to determine which eligible individuals initiate TPT
-        - If initiated, individuals are flagged as `on_tpt` for the treatment duration (`tpt_treatment_duration`)
-        - After completing treatment, individuals become protected (tb.state = TBS.PROTECTED) for a fixed duration (`tpt_protection_duration`)
-        - Protection is tracked using `tpt_protection_until` and is automatically removed when expired (tb.state set to TBS.NONE)
-    
-    Parameters:
-        p_tpt (float or ss.Bernoulli): Probability of initiating TPT for an eligible individual
-        age_range (list): [min_age, max_age] for eligibility (default: [0, 100])
-        hiv_status_threshold (bool): If True, only HIV-positive individuals are eligible (requires 'hiv_positive' attribute)
-        tpt_treatment_duration (float): Duration of TPT administration (e.g., 3 months)
-        tpt_protection_duration (float): Duration of post-treatment protection (e.g., 2 years)
-        start (ss.date): Start date for offering TPT
-        stop (ss.date): Stop date for offering TPT
+    Models a two-phase intervention: a **treatment phase** (antibiotic course)
+    followed by a **protection phase** (residual risk reduction via ``rr_*``
+    modifiers).  During treatment, no protection is applied; after treatment
+    completes, ``rr_activation``, ``rr_clearance``, and ``rr_death`` are
+    modified each step until protection expires.
 
-    Results tracked:
-        n_eligible (int): Number of individuals meeting criteria
-        n_tpt_initiated (int): Number of individuals who started TPT
-
-    Notes:
-        - Requires 'hhid', 'on_tpt', 'received_tpt', 'sought_care', 'non_symptomatic', 'symptomatic' attributes on people
-        - Assumes household structure is available (e.g., via HouseHoldNet)
-        - TB disease model must support 'protected_from_tb', 'tpt_treatment_until', and 'tpt_protection_until' states
-        - Protection logic mirrors BCG: tb.state is set to TBS.PROTECTED for the immunity period, then reset to TBS.NONE
-        - Uses care-seeking individuals as the index population for household contact tracing
+    Parameters
+    ----------
+    disease : str
+        Key of the disease module to target (default ``'tb'``).
+    dur_treatment : ss.Dist
+        Duration of the antibiotic course (default 3 months).
+    dur_protection : ss.Dist
+        Duration of post-treatment protection (default 2 years).
+    activation_modifier / clearance_modifier / death_modifier : ss.Dist
+        Per-individual risk-modifier distributions.
     """
 
     def __init__(self, pars=None, **kwargs):
-        """
-        Initialize the TPTInitiation intervention.
-
-        Args:
-            pars (dict, optional): Dictionary containing intervention parameters.
-            - 'p_tpt' (float or ss.Bernoulli): Probability of initiating TPT
-            - 'age_range' (list): [min_age, max_age] for eligibility (default: [0, 100])
-            - 'hiv_status_threshold' (bool): If True, only HIV-positive individuals are eligible
-            - 'tpt_treatment_duration' (float): Duration of TPT administration
-            - 'tpt_protection_duration' (float): Duration of post-treatment protection
-            - 'start' (date): Start date for offering TPT
-            - 'stop' (date): Stop date for offering TPT
-            **kwargs: Additional keyword arguments passed to parent class
-        """
         super().__init__(**kwargs)
         self.define_pars(
-            p_tpt=ss.bernoulli(p=1.0),
-            age_range=[0, 100],  # Default: all ages 0-99
-            hiv_status_threshold=False,
-            tpt_treatment_duration=ss.peryear(0.25),   # 3 months of treatment
-            tpt_protection_duration=ss.peryear(2.0),   # 2 years of protection
-            start=ss.date('2000-01-01'),
-            stop=ss.date('2100-12-31'),
+            disease='tb',
+            dur_treatment=ss.constant(v=ss.months(3)),
+            dur_protection=ss.constant(v=ss.years(2)),
+            activation_modifier=ss.uniform(0.3, 0.5),
+            clearance_modifier=ss.uniform(1.2, 1.4),
+            death_modifier=ss.uniform(0.1, 0.3),
         )
-        self.update_pars(pars=pars, **kwargs)
-        
-        # # Define states for TPT tracking
-        # self.define_states(
-        #     ss.BoolState('sought_care', default=False),
-        #     ss.BoolState('non_symptomatic', default=True),
-        #     ss.BoolState('symptomatic', default=False),
-        #     ss.BoolState('on_tpt', default=False),
-        #     ss.BoolState('received_tpt', default=False),
-        #     ss.IntArr('hhid', default=-1),
-        #     ss.BoolState('hiv_positive', default=False),
-        #     ss.FloatArr('tpt_treatment_until', default=np.nan),  # When TPT treatment ends
-        #     ss.FloatArr('tpt_protection_until', default=np.nan),  # When TPT protection ends
-        # )
-    
-    def step(self):
-        """
-        Execute the TPT intervention step, applying TPT and protection logic at each timestep.
+        self.update_pars(pars)
 
-        - Removes protection for individuals whose TPT protection has expired (tb.state set to TBS.NONE)
-        - Identifies agents who sought care (INDEX list)
-        - For all INDEX UIDs, identifies household members
-        - Filters household members for eligibility: no symptoms, no active TB, not on_treatment
-        - Uses a Bernoulli trial to select candidates for TPT
-        - Sets on_tpt and received_tpt flags for those who start TPT
-        - Sets tpt_treatment_until and tpt_protection_until for those who start TPT
-        - Sets tb.state to TBS.PROTECTED for the protection period after treatment
-        - Tracks results for eligibility and initiation
-        """
-        sim = self.sim
-        ppl = sim.people
-        tb = sim.diseases.tb
-
-        # TPT-related states are now defined in the TB disease module
-        # No need to dynamically define them here
-
-        # --- Remove protection if expired (simplified for now) ---
-        # TODO: Implement proper date-based expiration logic
-        # For now, we'll skip the expiration check to get the basic functionality working
-
-        # Find agents who sought care (INDEX list)
-        sought_care = ppl.sought_care
-        
-        # Safety check: ensure hhid array is properly initialized
-        if not hasattr(ppl, 'hhid') or len(ppl.hhid) == 0:
-            return
-            
-        # Get households of agents who sought care
-        eligible_hhids = np.unique(ppl['hhid'][sought_care])
-
-        # Eligibility screening for household members
-        in_eligible_households = np.isin(ppl['hhid'], eligible_hhids)
-        # Filter criteria: no symptoms, no active TB, not on_treatment
-        no_symptoms = ppl['non_symptomatic'] & (~ppl['symptomatic'])
-        no_active_tb = (tb.state != tbsim.TBS.ACTIVE_PRESYMP) & (tb.state != tbsim.TBS.ACTIVE_SMPOS) & (tb.state != tbsim.TBS.ACTIVE_SMNEG) & (tb.state != tbsim.TBS.ACTIVE_EXPTB)
-        not_on_treatment = ~tb.on_treatment
-        
-        eligible = in_eligible_households & no_symptoms & no_active_tb & not_on_treatment
-
-        # Age range filter (if age_range is set and present)
-        if hasattr(ppl, 'age') and self.pars.age_range is not None:
-            age_range = list(self.pars.age_range)
-            min_age, max_age = age_range[0], age_range[1]
-            eligible = eligible & (ppl['age'] >= min_age) & (ppl['age'] < max_age)
-
-        # HIV status filter (if hiv_status_threshold is set True and attribute present)
-        if self.pars.hiv_status_threshold and hasattr(ppl, 'hiv_positive'):
-            eligible = eligible & (ppl['hiv_positive'] == True)
-
-        # Bernoulli selection
-        tpt_candidates = self.pars.p_tpt.filter(eligible)
-
-        if len(tpt_candidates):
-            # Treatment phase
-            ppl['on_tpt'][tpt_candidates] = True
-            ppl['received_tpt'][tpt_candidates] = True
-
-            # Track treatment and future protection schedule
-            now = self.sim.now
-            if hasattr(now, 'date'):
-                now_date = now.date()
-            else:
-                now_date = now
-                
-            # Set treatment and protection end dates (simplified)
-            # For now, we'll use a simple approach without complex date arithmetic
-            tb.tpt_treatment_until[tpt_candidates] = self.sim.ti + 365  # 1 year from now (in time steps)
-            tb.tpt_protection_until[tpt_candidates] = self.sim.ti + 365*5  # 5 years from now (in time steps)
-
-            # Set TB state to PROTECTED after treatment ends
-            # (Assume protection starts immediately after treatment for simplicity)
-            tb.state[tpt_candidates] = tbsim.TBS.PROTECTED
-
-            # Result tracking
-            self.results['n_eligible'][self.ti] = np.count_nonzero(eligible)
-            self.results['n_tpt_initiated'][self.ti] = len(tpt_candidates)
-
-    def init_results(self):
-        super().init_results()
-        self.define_results(
-            ss.Result('n_eligible', dtype=int),
-            ss.Result('n_tpt_initiated', dtype=int),
+        self.define_states(
+            ss.BoolArr('tpt_protected', default=False),
+            ss.FloatArr('ti_protection_starts'),
+            ss.FloatArr('ti_protection_expires'),
+            ss.FloatArr('tpt_activation_modifier_applied'),
+            ss.FloatArr('tpt_clearance_modifier_applied'),
+            ss.FloatArr('tpt_death_modifier_applied'),
         )
+
+    def administer(self, people, uids):
+        """
+        Start TPT for *uids* (already accepted by the delivery intervention).
+
+        Samples per-agent modifiers and schedules the protection window
+        (starts after treatment completes, expires after ``dur_protection``).
+
+        Returns
+        -------
+        ss.uids
+            UIDs of agents who started treatment.
+        """
+        if len(uids) == 0:
+            return ss.uids()
+
+        dur_tx = self.pars.dur_treatment.rvs(uids)
+        dur_prot = self.pars.dur_protection.rvs(uids)
+
+        self.ti_protection_starts[uids] = self.ti + dur_tx
+        self.ti_protection_expires[uids] = self.ti + dur_tx + dur_prot
+
+        self.tpt_activation_modifier_applied[uids] = self.pars.activation_modifier.rvs(uids)
+        self.tpt_clearance_modifier_applied[uids] = self.pars.clearance_modifier.rvs(uids)
+        self.tpt_death_modifier_applied[uids] = self.pars.death_modifier.rvs(uids)
+
+        return uids
+
+    def update_roster(self):
+        """
+        Start protection for agents whose treatment completed;
+        expire protection for agents past their expiry time.
+        """
+        # Start protection for agents whose treatment just completed
+        not_yet_protected = (~self.tpt_protected).uids
+        if len(not_yet_protected) > 0:
+            starts = self.ti_protection_starts[not_yet_protected]
+            ready = not_yet_protected[
+                ~np.isnan(starts) & (self.ti >= starts)
+            ]
+            self.tpt_protected[ready] = True
+
+        # Expire protection
+        protected_uids = self.tpt_protected.uids
+        if len(protected_uids) > 0:
+            expired = protected_uids[
+                self.ti > self.ti_protection_expires[protected_uids]
+            ]
+            self.tpt_protected[expired] = False
+
+    def apply_protection(self):
+        """Multiply ``rr_*`` arrays for all currently protected agents."""
+        protected = self.tpt_protected.uids
+        if len(protected) > 0:
+            tb = self.sim.diseases[self.pars.disease]
+            tb.rr_activation[protected] *= self.tpt_activation_modifier_applied[protected]
+            tb.rr_clearance[protected] *= self.tpt_clearance_modifier_applied[protected]
+            tb.rr_death[protected] *= self.tpt_death_modifier_applied[protected]
+
+
+# ---------------------------------------------------------------------------
+# Delivery intervention
+# ---------------------------------------------------------------------------
+
+class TPTSimple(TBProductRoutine):
+    """
+    Simple TPT delivery targeting latently infected agents.
+
+    Thin wrapper over :class:`TBProductRoutine` that defaults to targeting
+    agents in ``TBSL.INFECTION`` state (latent TB).  Creates a
+    :class:`TPTTx` product automatically if none is provided.
+
+    Parameters
+    ----------
+    product : TPTTx
+        The TPT treatment product (created automatically if not provided).
+    pars : dict
+        Overrides for delivery parameters (``coverage``, ``age_range``,
+        ``eligible_states``, ``start``, ``stop``).
+    """
+
+    def __init__(self, product=None, pars=None, **kwargs):
+        super().__init__(
+            product=product if product is not None else TPTTx(),
+            pars=pars,
+            **kwargs,
+        )
+        # Default: target latently infected agents
+        if pars is None or 'eligible_states' not in (pars or {}):
+            self.pars.eligible_states = [TBSL.INFECTION]
 
     def update_results(self):
-        ppl = self.sim.people
-        self.results['n_eligible'][self.ti] = np.count_nonzero(ppl['on_tpt'] | ppl['received_tpt'])
-        self.results['n_tpt_initiated'][self.ti] = np.count_nonzero(ppl['on_tpt'])
+        super().update_results()
+        self.results['n_protected'][self.ti] = np.count_nonzero(self.product.tpt_protected)
 
-        
 
-class TPTRegimes():
-    """
-    Tuberculosis Preventive Therapy (TPT) Regimens - CDC 2024 Recommendations
-
-    This class defines latent TB infection (LTBI) treatment regimens and their
-    standard durations using `ss.peryear(...)`.
-
-    Regimens:
-        - 3HP: Isoniazid + Rifapentine, once weekly for 3 months
-            → ss.peryear(0.25)
-            Recommended for ages 2+ and people with HIV if ART-compatible.
-
-        - 4R: Rifampin, daily for 4 months
-            → ss.peryear(1/3)
-            Recommended for HIV-negative individuals and INH-intolerant cases.
-
-        - 3HR: Isoniazid + Rifampin, daily for 3 months
-            → ss.peryear(0.25)
-            Recommended for all ages, including some on ART.
-
-        - 6H: Isoniazid, daily for 6 months
-            → ss.peryear(0.5)
-            Used when rifamycins are not feasible.
-
-        - 9H: Isoniazid, daily for 9 months
-            → ss.peryear(0.75)
-            Alternative when shorter regimens are not suitable.
-
-    Source:
-        https://www.cdc.gov/tb/hcp/treatment/latent-tuberculosis-infection.html
-    """
-    cdc_3HP = ss.peryear(0.25)
-    cdc_4R  = ss.peryear(1/3)
-    cdc_3HR = ss.peryear(0.25)
-    cdc_6H  = ss.peryear(0.5)
-    cdc_9H  = ss.peryear(0.75)

--- a/tbsim_examples/run_tb_interventions.py
+++ b/tbsim_examples/run_tb_interventions.py
@@ -85,12 +85,12 @@ def build_sim(scenario=None, spars=None):
     if tpt_params:
         if isinstance(tpt_params, dict):
             # Single TPT intervention
-            interventions.append(tbsim.TPTInitiation(pars=tpt_params))
+            interventions.append(tbsim.TPTSimple(pars=tpt_params))
         elif isinstance(tpt_params, list):
             # Multiple TPT interventions
             for i, params in enumerate(tpt_params):
                 params['name'] = f'TPT_{i}'  # Give unique name
-                interventions.append(tbsim.TPTInitiation(pars=params))
+                interventions.append(tbsim.TPTSimple(pars=params))
     
     # Add Beta interventions (can be single or multiple)
     beta_params = scenario.get('betabyyear')

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -1,0 +1,223 @@
+"""Tests for TPTTx (product) and TPTSimple (delivery intervention)."""
+
+import numpy as np
+import pytest
+import starsim as ss
+import tbsim as mtb
+import pandas as pd
+from tbsim.interventions.tpt import TPTTx, TPTSimple
+from tbsim.tb_lshtm import TBSL
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_sim(agents=50, start=ss.date('2000-01-01'), stop=ss.date('2020-12-31'), dt=ss.days(7)):
+    pop = ss.People(n_agents=agents)
+    tb = mtb.TB_LSHTM(name='tb', pars={'init_prev': 0.30})
+    net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=5), dur=0))
+    pars = dict(dt=dt, start=start, stop=stop)
+    return pop, tb, net, pars
+
+
+age_data = pd.DataFrame({
+    'age':   [0, 2, 4, 10, 15, 20, 30, 40, 50, 60, 70, 80],
+    'value': [20, 10, 25, 15, 10, 5, 4, 3, 2, 1, 1, 1],
+})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_tpt_default_values():
+    """Test TPTSimple + TPTTx with default parameters."""
+    nagents = 100
+    pop, tb, net, pars = make_sim(agents=nagents)
+    itv = TPTSimple()
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+    tpt = sim.interventions['tptsimple']
+
+    # Delivery pars on the intervention
+    assert '0.5' in str(tpt.pars.coverage) or '0.50' in str(tpt.pars.coverage)
+    assert tpt.pars.eligible_states == [TBSL.INFECTION]
+
+    # Product pars
+    assert hasattr(tpt.product.pars, 'dur_treatment')
+    assert hasattr(tpt.product.pars, 'dur_protection')
+    assert tpt.product.pars.disease == 'tb'
+
+
+def test_tpt_custom_values():
+    """Test TPTSimple + TPTTx with custom parameters."""
+    nagents = 100
+    pop, tb, net, pars = make_sim(agents=nagents)
+    product = TPTTx(pars={
+        'dur_treatment': ss.constant(v=ss.months(6)),
+        'dur_protection': ss.constant(v=ss.years(5)),
+    })
+    itv = TPTSimple(product=product, pars={
+        'coverage': 0.8,
+        'age_range': [15, 65],
+        'start': ss.date('2005-01-01'),
+    })
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+    tpt = sim.interventions['tptsimple']
+
+    assert '0.8' in str(tpt.pars.coverage)
+    assert tpt.pars.age_range == [15, 65]
+    assert tpt.pars.start == ss.date('2005-01-01')
+
+
+def test_tpt_targets_latent_only():
+    """Test that TPT only targets agents in INFECTION (latent) state."""
+    nagents = 100
+    pop, tb, net, pars = make_sim(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+    itv = TPTSimple(pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+    tpt = sim.interventions['tptsimple']
+
+    tpt.step()
+
+    # Only latently infected agents should have been initiated
+    initiated_uids = tpt.initiated.uids
+    if len(initiated_uids) > 0:
+        tb_disease = sim.diseases.tb
+        states_of_initiated = np.asarray(tb_disease.state[initiated_uids])
+        # At administration time they were INFECTION; some may have transitioned since
+        # but at minimum they should have protection_starts set
+        assert np.all(~np.isnan(tpt.product.ti_protection_starts[initiated_uids]))
+
+
+def test_tpt_treatment_then_protection():
+    """Test the two-phase model: treatment first, then protection."""
+    nagents = 100
+    pop, tb, net, pars = make_sim(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    # Non-zero treatment duration — protection should not start immediately
+    product = TPTTx(pars={
+        'dur_treatment': ss.constant(v=ss.years(1)),
+        'dur_protection': ss.constant(v=ss.years(5)),
+    })
+    itv = TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+    tpt = sim.interventions['tptsimple']
+
+    # Step 1: initiate treatment — not yet protected (ti doesn't advance with manual step)
+    tpt.step()
+    initiated = tpt.initiated.uids
+    if len(initiated) > 0:
+        # Protection hasn't started yet (treatment takes 1 year)
+        assert not np.all(tpt.product.tpt_protected[initiated]), \
+            "Agents should not be protected immediately (treatment phase)"
+
+        # But protection_starts should be set in the future
+        starts = tpt.product.ti_protection_starts[initiated]
+        assert np.all(~np.isnan(starts)), "Protection start times should be set"
+        assert np.all(starts > tpt.ti), "Protection should start after treatment completes"
+
+
+def test_tpt_protection_expiry():
+    """Test that protection expires after dur_protection."""
+    nagents = 50
+    pop, tb, net, pars = make_sim(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    # Very short treatment + very short protection (1 timestep each)
+    product = TPTTx(pars={
+        'dur_treatment': ss.constant(v=ss.days(1)),
+        'dur_protection': ss.constant(v=ss.days(1)),
+    })
+    itv = TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+    tpt = sim.interventions['tptsimple']
+
+    # Step through enough times for treatment + protection to expire
+    for _ in range(5):
+        tpt.step()
+
+    # All protection should have expired
+    assert np.count_nonzero(tpt.product.tpt_protected) == 0, \
+        "All protection should have expired"
+
+
+def test_tpt_modifies_rr():
+    """Test that TPT applies rr_* modifiers for protected agents."""
+    nagents = 100
+    pop, tb, net, pars = make_sim(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    # Instant treatment so protection starts immediately
+    product = TPTTx(pars={
+        'dur_treatment': ss.constant(v=ss.days(0)),
+        'dur_protection': ss.constant(v=ss.years(10)),
+    })
+    itv = TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tb_disease = sim.diseases.tb
+    initial_activation = np.array(tb_disease.rr_activation).copy()
+
+    tpt = sim.interventions['tptsimple']
+    # Two steps: first to initiate + start protection (dur_treatment=0), second to apply
+    tpt.step()
+    tpt.step()
+
+    current_activation = np.array(tb_disease.rr_activation)
+
+    protected = tpt.product.tpt_protected.uids
+    if len(protected) > 0:
+        assert np.any(current_activation[protected] < initial_activation[protected]), \
+            "TPT should reduce activation risk for protected agents"
+
+
+def test_tpt_result_metrics():
+    """Test that result metrics are initialized and updated correctly."""
+    nagents = 50
+    pop, tb, net, pars = make_sim(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+    itv = TPTSimple()
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+    tpt = sim.interventions['tptsimple']
+
+    tpt.step()
+    tpt.update_results()
+
+    assert 'n_newly_initiated' in tpt.results
+    assert isinstance(tpt.results['n_newly_initiated'][tpt.ti], (int, np.integer))
+    assert 'n_protected' in tpt.results
+    assert isinstance(tpt.results['n_protected'][tpt.ti], (int, np.integer))
+
+
+def test_tpt_with_age_range():
+    """Test TPT delivery with age range filter."""
+    nagents = 100
+    pop, tb, net, pars = make_sim(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    itv = TPTSimple(pars={
+        'coverage': 1.0,
+        'age_range': [15, 50],
+    })
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+    tpt = sim.interventions['tptsimple']
+
+    tpt.step()
+
+    # Initiated agents should be within age range
+    initiated_uids = tpt.initiated.uids
+    if len(initiated_uids) > 0:
+        ages = np.asarray(sim.people.age[initiated_uids])
+        assert np.all(ages >= 15), "All initiated should be >= 15"
+        assert np.all(ages <= 50), "All initiated should be <= 50"


### PR DESCRIPTION
## Summary

- Extract `TBProductRoutine` shared delivery base class with composable eligibility filters (`age_range`, `eligible_states`, user-provided callable)
- Refactor `BCGRoutine` to thin wrapper over `TBProductRoutine`
- Replace broken `TPTInitiation` with `TPTTx` (ss.Product) + `TPTSimple` (TBProductRoutine)
- Remove dead code: old `Product` stub, `TBVaccinationCampaign`, `get_extrastates`, unused `TPTRegimes`

### Architecture

```
TBProductRoutine (shared base)
├── BCGRoutine  (age 0-5 default)     + BCGVx (ss.Vx)
└── TPTSimple   (latent TB default)   + TPTTx (ss.Product)
```

Products expose a uniform interface: `update_roster()`, `administer()`, `apply_protection()`.

### Key changes

| File | Change |
|------|--------|
| `interventions/interventions.py` | Replace dead code with `TBProductRoutine` |
| `interventions/bcg.py` | `BCGRoutine` extends `TBProductRoutine`; `BCGVx` adds `update_roster()` |
| `interventions/tpt.py` | `TPTTx` (treatment→protection phases via rr_*) + `TPTSimple` |
| `interventions/__init__.py` | Updated exports |
| `tests/test_bcg.py` | Updated for shared base state names |
| `tests/test_tpt.py` | New — 8 tests |
| `tbsim_examples/run_tb_interventions.py` | `TPTInitiation` → `TPTSimple` |

Closes #214, closes #216, closes #308
Relates to #125

## Test plan

- [x] `pytest tests/test_bcg.py` — 10/10 pass
- [x] `pytest tests/test_tpt.py` — 8/8 pass
- [x] `pytest tests/test_tb_lshtm.py` — 32/32 pass
- [x] Zero remaining `TPTInitiation` references