### PR TITLE
fix tb acute latent rate units

### DIFF
--- a/tbsim_examples/run_tb_lshtm.py
+++ b/tbsim_examples/run_tb_lshtm.py
@@ -28,7 +28,7 @@ tb_params = {
     "cxr_asymp_sens": 1.0,         # CXR sensitivity for asymptomatic (0–1)
 
     # Acute variant only (ignored if use_acute is False)
-    "rate_acute_latent": ss.years(ss.expon(1 / 4.0)),  # ACUTE → INFECTION
+    "rate_acute_latent": ss.peryear(4.0),   # ACUTE → INFECTION
     "trans_acute": 0.9,            # α alpha: relative transmissibility from acute
 }
 


### PR DESCRIPTION
## Summary
- Fixes `rate_acute_latent` in `tbsim_examples/run_tb_lshtm.py` to use a per-year rate (`ss.peryear(4.0)`) instead of a duration distribution.
- Prevents Starsim distribution initialization from erroring due to mixed time units.

Closes #339 

## Test plan
- Run `python tbsim_examples/run_tb_lshtm.py`.

Made with [Cursor](https://cursor.com)