### PR TITLE
Simplify TB_LSHTM: eliminate ti_next/state_next, immediate transitions

### DIFF
--- a/tbsim/tb_lshtm.py
+++ b/tbsim/tb_lshtm.py
@@ -37,14 +37,10 @@ class TBSL(IntEnum):
         return np.array([TBSL.SYMPTOMATIC])
 
 
-
-
-
-
 class TB_LSHTM(ss.Infection):
     """
-    Agent-based TB natural history adapting the LSHTM compartmental structure [1] (Schwalb et al. 2025). 
-    States in :class:`TBSL` span the spectrum from susceptibility to active disease and treatment.  
+    Agent-based TB natural history adapting the LSHTM compartmental structure [1] (Schwalb et al. 2025).
+    States in :class:`TBSL` span the spectrum from susceptibility to active disease and treatment.
     Infectious states are :class:`TBSL.ASYMPTOMATIC` and :class:`TBSL.SYMPTOMATIC`; the force
     of infection depends on :attr:`pars.beta` and the prevalence of those states, with
     :attr:`pars.trans_asymp` (κ kappa) giving the relative infectiousness of asymptomatic vs symptomatic TB.
@@ -56,21 +52,21 @@ class TB_LSHTM(ss.Infection):
     -----------------
     *Transmission and reinfection*
 
-    - ``init_prev``:   Initial seed infections (prevalence). 
-    - ``beta``:        Transmission rate per year. 
-    - ``trans_asymp``: Relative transmissibility, asymptomatic vs symptomatic. (κ kappa) 
-    - ``rr_rec``:      Relative risk of reinfection for RECOVERED.  (π pi) 
-    - ``rr_treat``:    Relative risk of reinfection for TREATED. (ρ rho) 
+    - ``init_prev``:   Initial seed infections (prevalence).
+    - ``beta``:        Transmission rate per year.
+    - ``trans_asymp``: Relative transmissibility, asymptomatic vs symptomatic. (κ kappa)
+    - ``rr_rec``:      Relative risk of reinfection for RECOVERED.  (π pi)
+    - ``rr_treat``:    Relative risk of reinfection for TREATED. (ρ rho)
 
     *From INFECTION (latent)*
 
-    - ``inf_cle``:     Infection → Cleared (no active TB). 
-    - ``inf_non``:     Infection → Non-infectious TB. 
-    - ``inf_asy``:     Infection → Asymptomatic TB. 
+    - ``inf_cle``:     Infection → Cleared (no active TB).
+    - ``inf_non``:     Infection → Non-infectious TB.
+    - ``inf_asy``:     Infection → Asymptomatic TB.
 
     *From NON_INFECTIOUS*
 
-    - ``non_rec``:    Non-infectious → Recovered. 
+    - ``non_rec``:    Non-infectious → Recovered.
     - ``non_asy``:    Non-infectious → Asymptomatic.
 
     *From ASYMPTOMATIC*
@@ -80,18 +76,18 @@ class TB_LSHTM(ss.Infection):
 
     *From SYMPTOMATIC*
 
-    - ``sym_asy``:     Symptomatic → Asymptomatic. 
+    - ``sym_asy``:     Symptomatic → Asymptomatic.
     - ``sym_treat``:   Symptomatic → Treatment. (θ theta)
     - ``sym_dead``:    Symptomatic → Dead (TB-specific mortality, μ_TB).
 
     *From TREATMENT*
 
-    - ``fail_rate``:     Treatment → Symptomatic (failure). (φ phi) 
-    - ``complete_rate``: Treatment → Treated (completion).  (δ delta) 
+    - ``fail_rate``:     Treatment → Symptomatic (failure). (φ phi)
+    - ``complete_rate``: Treatment → Treated (completion).  (δ delta)
 
     *Background (general mortality is handled by* ``ss.Deaths`` *demographics, not this module)*
 
-    - ``cxr_asymp_sens``:   CXR sensitivity for screening asymptomatic (0–1). 
+    - ``cxr_asymp_sens``:   CXR sensitivity for screening asymptomatic (0–1).
 
     Agent states (array-like, one per agent)
     ---------------------------------------
@@ -106,8 +102,6 @@ class TB_LSHTM(ss.Infection):
     *TB state machine*
 
     - ``state``          (FloatArr, default=TBSL.SUSCEPTIBLE):  Current TB state (:class:`TBSL` value).
-    - ``state_next``     (FloatArr, default=TBSL.INFECTION):    Scheduled next state.
-    - ``ti_next``        (FloatArr, default=inf):               Time of next transition.
     - ``ti_infected``    (FloatArr, default=-inf):              Time of infection (never infected = -inf).
 
     *Transmission modifiers*
@@ -175,19 +169,18 @@ class TB_LSHTM(ss.Infection):
         self.define_states(
             ss.BoolState('susceptible', default=True),
             ss.BoolState('infected'),
-            ss.FloatArr('rel_sus', default=1.0),                 # Relative susceptibility to TB (default 1.0)
-            ss.FloatArr('rel_trans', default=1.0),               # Relative transmissibility of TB (default 1.0)
+            ss.FloatArr('rel_sus', default=1.0),
+            ss.FloatArr('rel_trans', default=1.0),
             ss.FloatArr('ti_infected', default=-np.inf),
-            ss.FloatArr('state', default=TBSL.SUSCEPTIBLE),       # Current TB state
-            ss.FloatArr('state_next', default=TBSL.INFECTION),   # Scheduled next state
-            ss.FloatArr('ti_next', default=np.inf),              # Time of next transition
+            ss.FloatArr('state', default=TBSL.SUSCEPTIBLE),
+            ss.FloatArr('ti_asymp', default=np.nan),                # Time of last entry to ASYMPTOMATIC (for new_active tracking)
             ss.BoolState('on_treatment', default=False),
             ss.BoolState('ever_infected', default=False),
             # Risk modifiers
-            ss.FloatArr('rr_activation', default=1.0),           # Multiplier on infection-to-active rate (INFECTION → NON_INFECTIOUS, ASYMPTOMATIC)
-            ss.FloatArr('rr_clearance', default=1.0),            # Multiplier on active-to-clearance rate (NON_INFECTIOUS → RECOVERED)
-            ss.FloatArr('rr_death', default=1.0),                # Multiplier on active-to-death rate (SYMPTOMATIC → DEAD)
-            reset=True,  # Replace base Infection states so we can set ti_infected default
+            ss.FloatArr('rr_activation', default=1.0),
+            ss.FloatArr('rr_clearance', default=1.0),
+            ss.FloatArr('rr_death', default=1.0),
+            reset=True,
         )
 
         return
@@ -208,57 +201,34 @@ class TB_LSHTM(ss.Infection):
 
         The base :class:`starsim.Infection` calls this when a susceptible agent
         acquires infection. We mark agents infected and set state to INFECTION
-        (latent). No transition scheduling — :meth:`step` evaluates transitions
-        per dt each timestep.
-
-        Parameters
-        ----------
-        uids : array-like
-            Agent indices that have just been infected.
-        sources : array-like or int, optional
-            Source agents (base class uses for seeding; -1 for initial cases).
+        (latent). Transitions are evaluated per dt each timestep in :meth:`step`.
         """
         super().set_prognoses(uids, sources)
         if len(uids) == 0:
             return
 
-        # Mark as infected and record infection time
         self.susceptible[uids] = False
         self.infected[uids] = True
         self.ever_infected[uids] = True
         self.ti_infected[uids] = self.ti
-
         self.state[uids] = TBSL.INFECTION
 
         return
 
     def transition(self, uids, to, rng):
         """
-        Evaluate competing exponential transitions over one dt.
+        Evaluate competing exponential transitions over one dt and apply immediately.
 
-        For each agent in `uids`, computes the probability of transitioning
-        to each destination in `to` during one timestep. Uses a single uniform
+        For each agent in *uids*, computes the probability of transitioning
+        to each destination in *to* during one timestep. Uses a single uniform
         draw per agent to decide (a) whether the agent transitions and
-        (b) which destination it goes to. Directly sets ``state_next`` and
-        ``ti_next`` on agents that draw to transition.
+        (b) which destination it goes to. State is updated **immediately**.
 
-        Parameters
-        ----------
-        uids : array-like
-            Agent indices to evaluate.
-        to : dict
-            Mapping from TBSL state -> ``ss.Rate``. Keys are possible next
-            states; values are ``ss.peryear`` (or other ``ss.per``) rates,
-            either scalar (same for all agents) or with per-agent ``.value``
-            (from ``par * rr_array[uids]``).
-        rng : ss.random
-            CRN-safe uniform RNG for this source state.
         """
         if len(uids) == 0:
             return
 
-        ti = self.ti
-        dt = self.sim.t.dt  # module dt as ss.dur
+        dt = self.sim.t.dt
         n = len(uids)
         states = list(to.keys())
         n_dest = len(states)
@@ -266,7 +236,7 @@ class TB_LSHTM(ss.Infection):
         # Convert each rate to dimensionless "rate per dt" using its own unit
         rates_per_dt = np.zeros((n_dest, n))
         for idx, rate_val in enumerate(to.values()):
-            factor = dt / rate_val.unit  # e.g. ss.days(7) / ss.years(1) = 7/365
+            factor = dt / rate_val.unit
             v = rate_val.value
             rates_per_dt[idx] = np.broadcast_to(v, n) * factor
 
@@ -277,10 +247,9 @@ class TB_LSHTM(ss.Infection):
         p_any = 1 - np.exp(-total_rate_dt)
 
         # Build CDF bins for destination selection
-        # cum_p[i] = P(transition to state 0..i) = sum(λ_j/Λ for j<=i) * p_any
         with np.errstate(divide='ignore', invalid='ignore'):
             fractions = np.where(total_rate_dt > 0, rates_per_dt / total_rate_dt, 0)
-        cum_p = np.cumsum(fractions, axis=0) * p_any  # shape (n_dest, n)
+        cum_p = np.cumsum(fractions, axis=0) * p_any
 
         # Single uniform draw per agent
         u = rng.rvs(uids)
@@ -295,41 +264,33 @@ class TB_LSHTM(ss.Infection):
         t_uids = uids[t_idx]
         t_u = u[t_idx]
         t_cum_p = cum_p[:, t_idx]
-
-        # Smallest i where u < cum_p[i]
         dest_idx = (t_u[None, :] < t_cum_p).argmax(axis=0)
         dest_states = np.array(states)[dest_idx]
 
-        # Set state_next and ti_next for transitioning agents
-        self.state_next[t_uids] = dest_states
-        self.ti_next[t_uids] = ti
+        # Apply state change immediately
+        self.state[t_uids] = dest_states
+
+        # Record ti_asymp for new-active tracking
+        newly_asymp = t_uids[dest_states == TBSL.ASYMPTOMATIC]
+        if len(newly_asymp):
+            self.ti_asymp[newly_asymp] = self.ti
 
     def step(self):
         """
         Advance TB state machine one timestep.
 
-        Order of operations:
-
-        1. **Transmission** (via ``super().step()``): handles force of infection
-           and calls :meth:`set_prognoses` for newly infected agents.
-        2. **Evaluate transitions**: for all agents in each state, evaluate
-           competing-risk transitions over one dt. Agents that draw to
-           transition get ``state_next``/``ti_next`` set. Agents already
-           force-scheduled (e.g. by :meth:`start_treatment`) are skipped.
-        3. **Apply transitions**: agents with ``ti >= ti_next`` move to their
-           new state. Bookkeeping (infected/susceptible flags, rel_sus/rel_trans,
-           deaths, results) is done here.
-        4. **Reset RR multipliers** for agents that transitioned (external
-           modules set fresh values each step before transmission).
+        1. **Transmission** (via ``super().step()``): handles force of infection.
+        2. **Reset RR multipliers** for all agents (interventions set fresh each step).
+        3. **Evaluate transitions**: for each state group, evaluate competing-risk
+           transitions and apply immediately. Agents may cascade through multiple
+           states in one step.
+        4. **Bookkeeping**: update flags, modifiers, deaths, results.
         """
         super().step()
-        ti = self.ti
 
-        # --- Phase 1: Evaluate transitions for all agents in each state ---
-        # Skip agents already force-scheduled by start_treatment (ti_next <= ti)
+        # --- Evaluate transitions (each mutates self.state in place) ---
 
-        # INFECTION → CLEARED, NON_INFECTIOUS, or ASYMPTOMATIC
-        u = ss.uids((self.state == TBSL.INFECTION) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.INFECTION)
         if len(u):
             self.transition(u, to={
                 TBSL.CLEARED:        self.pars.inf_cle,
@@ -337,24 +298,21 @@ class TB_LSHTM(ss.Infection):
                 TBSL.ASYMPTOMATIC:   self.pars.inf_asy * self.rr_activation[u],
             }, rng=self._rng_inf)
 
-        # NON_INFECTIOUS → RECOVERED or ASYMPTOMATIC
-        u = ss.uids((self.state == TBSL.NON_INFECTIOUS) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.NON_INFECTIOUS)
         if len(u):
             self.transition(u, to={
                 TBSL.RECOVERED:    self.pars.non_rec * self.rr_clearance[u],
                 TBSL.ASYMPTOMATIC: self.pars.non_asy,
             }, rng=self._rng_non)
 
-        # ASYMPTOMATIC → NON_INFECTIOUS or SYMPTOMATIC
-        u = ss.uids((self.state == TBSL.ASYMPTOMATIC) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.ASYMPTOMATIC)
         if len(u):
             self.transition(u, to={
                 TBSL.NON_INFECTIOUS: self.pars.asy_non,
                 TBSL.SYMPTOMATIC:    self.pars.asy_sym,
             }, rng=self._rng_asy)
 
-        # SYMPTOMATIC → ASYMPTOMATIC, TREATMENT, or DEAD
-        u = ss.uids((self.state == TBSL.SYMPTOMATIC) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.SYMPTOMATIC)
         if len(u):
             self.transition(u, to={
                 TBSL.ASYMPTOMATIC: self.pars.sym_asy,
@@ -362,109 +320,74 @@ class TB_LSHTM(ss.Infection):
                 TBSL.DEAD:         self.pars.sym_dead * self.rr_death[u],
             }, rng=self._rng_sym)
 
-        # TREATMENT → SYMPTOMATIC (failure) or TREATED (completion)
-        u = ss.uids((self.state == TBSL.TREATMENT) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.TREATMENT)
         if len(u):
             self.transition(u, to={
                 TBSL.SYMPTOMATIC: self.pars.fail_rate,
                 TBSL.TREATED:     self.pars.complete_rate,
             }, rng=self._rng_trt)
 
-        # CLEARED, RECOVERED, TREATED: no spontaneous transition; reinfection via transmission only
+        # --- Bookkeep from current state ---
 
-        # --- Phase 2: Apply transitions for agents with ti_next <= ti ---
+        self.infected[:] = ~np.isin(self.state,
+            [TBSL.SUSCEPTIBLE, TBSL.CLEARED, TBSL.RECOVERED, TBSL.TREATED, TBSL.DEAD])
+        self.susceptible[:] = np.isin(self.state,
+            [TBSL.SUSCEPTIBLE, TBSL.CLEARED, TBSL.RECOVERED, TBSL.TREATED])
+        self.on_treatment[:] = (self.state == TBSL.TREATMENT)
 
-        # Reset RR multipliers for ALL agents (interventions set fresh values each step)
+        # TB deaths
+        dead = ss.uids((self.state == TBSL.DEAD) & self.sim.people.alive)
+        self.sim.people.request_death(dead)
+        self.results['new_deaths'][self.ti] = len(dead)
+        self.results['new_deaths_15+'][self.ti] = np.count_nonzero(self.sim.people.age[dead] >= 15)
+
+        # Reset rr_* (interventions set fresh values next step)
         self.rr_activation[:] = 1
         self.rr_clearance[:] = 1
         self.rr_death[:] = 1
 
-        uids = ss.uids(ti >= self.ti_next)
-        if len(uids) == 0:
-            return
-
-        # Record outcomes from state_next *before* overwriting state
-        new_asymp_uids = uids[
-            (self.state_next[uids] == TBSL.ASYMPTOMATIC) &
-            (self.state[uids] != TBSL.SYMPTOMATIC)
-        ]
-        self.results['new_active'][ti] = len(new_asymp_uids)
-        self.results['new_active_15+'][ti] = np.count_nonzero(self.sim.people.age[new_asymp_uids] >= 15)
-
-        # Keep infected/susceptible in sync with state
-        new_inf_uids = uids[self.state_next[uids] == TBSL.INFECTION]
-        self.infected[new_inf_uids] = True
-        new_clr_uids = uids[np.isin(self.state_next[uids], [TBSL.CLEARED, TBSL.RECOVERED, TBSL.TREATED])]
-        self.infected[new_clr_uids] = False
-
-        # Apply the transition
-        self.state[uids] = self.state_next[uids]
-        self.ti_next[uids] = np.inf  # Clear to avoid double-firing
-        self.on_treatment[uids] = (self.state[uids] == TBSL.TREATMENT)
-
-        self.susceptible[uids] = np.isin(self.state[uids], [TBSL.CLEARED, TBSL.RECOVERED, TBSL.TREATED])
-
-        # TB deaths
-        new_death_uids = uids[self.state_next[uids] == TBSL.DEAD]
-        self.sim.people.request_death(new_death_uids)
-        self.results['new_deaths'][ti] = len(new_death_uids)
-        self.results['new_deaths_15+'][ti] = np.count_nonzero(self.sim.people.age[new_death_uids] >= 15)
-
-        # rel_sus: RECOVERED/TREATED at higher risk (π pi, ρ rho)
+        # rel_sus / rel_trans
         self.rel_sus[:] = 1
         self.rel_sus[self.state == TBSL.RECOVERED] = self.pars.rr_rec
         self.rel_sus[self.state == TBSL.TREATED] = self.pars.rr_treat
-
-        # rel_trans: ASYMPTOMATIC (κ kappa)
         self.rel_trans[:] = 1
         self.rel_trans[self.state == TBSL.ASYMPTOMATIC] = self.pars.trans_asymp
-
-        return
 
     def start_treatment(self, uids):
         """
         Move specified agents onto TB treatment (or clear latent infection).
 
         Called by interventions (e.g. screening/case-finding) when an agent is
-        identified for treatment. We set state_next and ti_next to the *current*
-        time so the change takes effect on the next :meth:`step` (no extra delay).
+        identified for treatment. State is changed immediately.
 
         - Latent (INFECTION): cleared without treatment (→ CLEARED).
         - Active (NON_INFECTIOUS, ASYMPTOMATIC, SYMPTOMATIC): moved to TREATMENT.
         - Records new notifications (15+) for active cases starting treatment.
-
-        Parameters
-        ----------
-        uids : array-like
-            Agent indices to start treatment (or clear if latent).
         """
         if len(uids) == 0:
-            return 0
+            return
 
         # Latent infection: clear without active disease
-        u = uids[self.state[uids] == TBSL.INFECTION]
-        self.state_next[u] = TBSL.CLEARED
-        self.ti_next[u] = self.ti
+        latent = uids[self.state[uids] == TBSL.INFECTION]
+        self.state[latent] = TBSL.CLEARED
+        self.infected[latent] = False
+        self.susceptible[latent] = True
 
-        # Active TB (non-infectious, asymptomatic, symptomatic): put on treatment
-        u = uids[np.isin(self.state[uids], [TBSL.NON_INFECTIOUS, TBSL.ASYMPTOMATIC, TBSL.SYMPTOMATIC])]
-        self.state_next[u] = TBSL.TREATMENT
-        self.ti_next[u] = self.ti
+        # Active TB: put on treatment
+        active = uids[np.isin(self.state[uids], [TBSL.NON_INFECTIOUS, TBSL.ASYMPTOMATIC, TBSL.SYMPTOMATIC])]
+        self.state[active] = TBSL.TREATMENT
+        self.on_treatment[active] = True
 
-        self.results['new_notifications_15+'][self.ti] += np.count_nonzero(self.sim.people.age[u] >= 15)
+        self.results['new_notifications_15+'][self.ti] += np.count_nonzero(self.sim.people.age[active] >= 15)
 
         return
 
     def step_die(self, uids):
         """
-        Apply death for the given agents and update TB state so they no longer participate.
+        Apply death for the given agents and update TB state.
 
-        Called by the framework when agents die (e.g. background mortality or
-        other modules). We:
-
-        - Set state to DEAD; clear susceptible and infected flags
-        - Set rel_trans=0 so they do not transmit
-        - Set ti_next=inf so no further TB transitions are scheduled
+        Called by the framework when agents die (e.g. background mortality).
+        Sets state to DEAD, clears flags, and stops transmission.
         """
         if len(uids) == 0:
             return
@@ -473,24 +396,11 @@ class TB_LSHTM(ss.Infection):
         self.susceptible[uids] = False
         self.infected[uids] = False
         self.state[uids] = TBSL.DEAD
-        self.ti_next[uids] = np.inf
         self.rel_trans[uids] = 0
         return
 
     def init_results(self):
-        """
-        Define result time series (counts by state, incidence, prevalence, etc.).
-
-        Called once when the simulation is set up. Registers:
-
-        - Per-state counts (n_* and n_*_15+) for each TBSL state
-        - Infectious counts, new/cumulative active cases and deaths
-        - Prevalence, incidence per 1000 person-years, deaths per person-year
-        - Notifications and detectable (symptomatic + CXR sensitivity * asymptomatic) for 15+
-
-        Actual values are filled in :meth:`update_results` each step and
-        :meth:`finalize_results` after the run.
-        """
+        """Define result time series."""
         super().init_results()
 
         results = []
@@ -512,25 +422,14 @@ class TB_LSHTM(ss.Infection):
             ss.Result('cum_deaths_15+',    dtype=int, label='Cumulative Deaths, 15+'),
             ss.Result('prevalence_active', dtype=float, scale=False, label='Prevalence (Active)'),
             ss.Result('incidence_kpy',     dtype=float, scale=False, label='Incidence per 1,000 person-years'),
-            ss.Result('deaths_ppy',        dtype=float, label='Death per person-year'), 
-            ss.Result('new_notifications_15+', dtype=int, label='New TB notifications, 15+'), 
-
+            ss.Result('deaths_ppy',        dtype=float, label='Death per person-year'),
+            ss.Result('new_notifications_15+', dtype=int, label='New TB notifications, 15+'),
             ss.Result('n_detectable_15+', dtype=float, scale=False, label='Symptomatic plus cxr_asymp_sens * Asymptomatic (15+)'),
         )
         return
 
     def update_results(self):
-        """
-        Record current time-step values for all result series.
-
-        Called each time step after :meth:`step`. Fills in:
-
-        - State counts (all ages and 15+) for each TBSL state
-        - Infectious counts, prevalence (active / alive)
-        - Incidence per 1000 person-years (new infections this step / person-years at risk)
-        - Deaths per person-year
-        - Detectable 15+ (symptomatic + CXR sens * asymptomatic, for screening)
-        """
+        """Record current time-step values for all result series."""
         super().update_results()
         res = self.results
         ti = self.ti
@@ -544,11 +443,13 @@ class TB_LSHTM(ss.Infection):
         res.n_infectious[ti] = np.count_nonzero(self.infectious)
         res['n_infectious_15+'][ti] = np.count_nonzero(self.infectious & (self.sim.people.age >= 15))
         res.prevalence_active[ti] = res.n_infectious[ti] / np.count_nonzero(self.sim.people.alive)
-        # Incidence: new infections at time ti, per 1000 person-years (denom = alive * dt_year)
         res.incidence_kpy[ti] = 1_000 * np.count_nonzero(ti_infctd == ti) / (np.count_nonzero(self.sim.people.alive) * dty)
         res.deaths_ppy[ti] = res.new_deaths[ti] / (np.count_nonzero(self.sim.people.alive) * dty)
 
-        # Detectable 15+: count symptomatic + (CXR sensitivity * asymptomatic) for screening
+        # New active: agents whose ti_asymp == this step
+        res['new_active'][ti] = np.count_nonzero(self.ti_asymp == ti)
+        res['new_active_15+'][ti] = np.count_nonzero((self.ti_asymp == ti) & (self.sim.people.age >= 15))
+
         res['n_detectable_15+'][ti] = np.dot(
             self.sim.people.age >= 15,
             (self.state == TBSL.SYMPTOMATIC) + self.pars.cxr_asymp_sens * (self.state == TBSL.ASYMPTOMATIC)
@@ -557,17 +458,7 @@ class TB_LSHTM(ss.Infection):
         return
 
     def finalize_results(self):
-        """
-        Compute cumulative series from new-event series after the run.
-
-        Called once when the simulation ends. Fills cumulative series by cumsum
-        of the corresponding new_* arrays:
-
-        - cum_deaths, cum_deaths_15+ from new_deaths, new_deaths_15+
-        - cum_active, cum_active_15+ from new_active, new_active_15+
-
-        So cum_*[t] = sum of new_* from start up to time t.
-        """
+        """Compute cumulative series from new-event series after the run."""
         super().finalize_results()
         res = self.results
         res['cum_deaths'] = np.cumsum(res['new_deaths'])
@@ -577,16 +468,7 @@ class TB_LSHTM(ss.Infection):
         return
 
     def plot(self):
-        """
-        Plot all result time series on one figure.
-
-        - Plots every key in :attr:`results` except ``timevec``.
-        - Uses ``timevec`` for the x-axis.
-
-        Returns
-        -------
-        matplotlib.figure.Figure
-        """
+        """Plot all result time series on one figure."""
         fig = plt.figure()
         for rkey in self.results.keys():
             if rkey == 'timevec':
@@ -603,60 +485,28 @@ class TB_LSHTM_Acute(TB_LSHTM):
     Extends :class:`TB_LSHTM` by inserting an ACUTE state between infection and
     the usual INFECTION (latent) state. New infections enter ACUTE first, then
     transition to INFECTION at rate :attr:`pars.rate_acute_latent`. Acute cases are
-    infectious with relative transmissibility :attr:`pars.trans_acute` (α alpha). All other
-    states and transitions match :class:`TB_LSHTM`.
-
-    State flow (difference from base)
-    ---------------------------------
-    - Transmission → ACUTE (not INFECTION).
-    - From ACUTE the only spontaneous transition is ACUTE → INFECTION at rate_acute_latent.
-    - Once in INFECTION, flow is as in the base (CLEARED, NON_INFECTIOUS, ASYMPTOMATIC, etc.).
-    - Reinfection of CLEARED/RECOVERED/TREATED again leads to ACUTE.
-    - When :meth:`start_treatment` is called, both ACUTE and INFECTION (latent)
-      are cleared; active states go to TREATMENT as in the base.
+    infectious with relative transmissibility :attr:`pars.trans_acute` (α alpha).
     """
 
     def __init__(self, pars=None, **kwargs):
-        """
-        Initialize the acute-variant model; adds ACUTE-state parameters.
-
-        Parameters
-        ----------
-        pars : dict, optional
-            Override parameters (e.g. ``rate_acute_latent``, ``trans_acute``).
-        **kwargs
-            Passed to base.
-        """
         super().__init__(pars=pars, **kwargs)
 
-        # ACUTE is a brief infectious state before latent (INFECTION); reinfection leads to ACUTE
         self.define_pars(
-            rate_acute_latent=ss.peryear(4.0),  # ACUTE → INFECTION (per year)
-            trans_acute=0.9,                    # α alpha: rel. transmissibility acute vs symptomatic
+            rate_acute_latent=ss.peryear(4.0),
+            trans_acute=0.9,
         )
         self.update_pars(pars, **kwargs)
 
-        # CRN-safe RNG for ACUTE state transitions
         self._rng_acu = ss.random(name='tb_rng_acu')
         return
 
     @property
     def infectious(self):
-        """
-        Boolean array: True for agents who can transmit TB.
-
-        Includes ACUTE in addition to ASYMPTOMATIC and SYMPTOMATIC.
-        """
+        """Includes ACUTE in addition to ASYMPTOMATIC and SYMPTOMATIC."""
         return (self.state == TBSL.ACUTE) | (self.state == TBSL.ASYMPTOMATIC) | (self.state == TBSL.SYMPTOMATIC)
 
     def set_prognoses(self, uids, sources=None):
-        """
-        Set prognoses for newly infected agents; they enter ACUTE (not INFECTION).
-
-        Skips TB_LSHTM.set_prognoses (which would set state=INFECTION) and calls
-        ss.Infection.set_prognoses directly, then sets ACUTE state. No transition
-        scheduling — :meth:`step` evaluates transitions per dt each timestep.
-        """
+        """New infections enter ACUTE (not INFECTION)."""
         super(TB_LSHTM, self).set_prognoses(uids, sources)
         if len(uids) == 0:
             return
@@ -665,7 +515,6 @@ class TB_LSHTM_Acute(TB_LSHTM):
         self.infected[uids] = True
         self.ever_infected[uids] = True
         self.ti_infected[uids] = self.ti
-
         self.state[uids] = TBSL.ACUTE
 
         return
@@ -674,30 +523,18 @@ class TB_LSHTM_Acute(TB_LSHTM):
         """
         Advance TB state machine one timestep (acute variant).
 
-        Same two-phase structure as :meth:`TB_LSHTM.step`, but:
-
-        - Adds ACUTE → INFECTION transition evaluation.
-        - Treats ACUTE as infectious (infected-flag and rel_trans).
-        - Reinfection leads to ACUTE (handled in set_prognoses).
-
-        Calls ``super(TB_LSHTM, self).step()`` for transmission (bypasses
-        TB_LSHTM.step to avoid double evaluation).
+        Same single-pass structure as :meth:`TB_LSHTM.step`, but adds
+        ACUTE → INFECTION transition and treats ACUTE as infectious.
         """
         super(TB_LSHTM, self).step()
-        ti = self.ti
 
-        # --- Phase 1: Evaluate transitions for all agents in each state ---
-        # Skip agents already force-scheduled by start_treatment (ti_next <= ti)
+        # --- Evaluate transitions ---
 
-        # ACUTE → INFECTION
-        u = ss.uids((self.state == TBSL.ACUTE) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.ACUTE)
         if len(u):
-            self.transition(u, to={
-                TBSL.INFECTION: self.pars.rate_acute_latent,
-            }, rng=self._rng_acu)
+            self.transition(u, to={TBSL.INFECTION: self.pars.rate_acute_latent}, rng=self._rng_acu)
 
-        # INFECTION → CLEARED, NON_INFECTIOUS, or ASYMPTOMATIC
-        u = ss.uids((self.state == TBSL.INFECTION) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.INFECTION)
         if len(u):
             self.transition(u, to={
                 TBSL.CLEARED:        self.pars.inf_cle,
@@ -705,24 +542,21 @@ class TB_LSHTM_Acute(TB_LSHTM):
                 TBSL.ASYMPTOMATIC:   self.pars.inf_asy * self.rr_activation[u],
             }, rng=self._rng_inf)
 
-        # NON_INFECTIOUS → RECOVERED or ASYMPTOMATIC
-        u = ss.uids((self.state == TBSL.NON_INFECTIOUS) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.NON_INFECTIOUS)
         if len(u):
             self.transition(u, to={
                 TBSL.RECOVERED:    self.pars.non_rec * self.rr_clearance[u],
                 TBSL.ASYMPTOMATIC: self.pars.non_asy,
             }, rng=self._rng_non)
 
-        # ASYMPTOMATIC → NON_INFECTIOUS or SYMPTOMATIC
-        u = ss.uids((self.state == TBSL.ASYMPTOMATIC) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.ASYMPTOMATIC)
         if len(u):
             self.transition(u, to={
                 TBSL.NON_INFECTIOUS: self.pars.asy_non,
                 TBSL.SYMPTOMATIC:    self.pars.asy_sym,
             }, rng=self._rng_asy)
 
-        # SYMPTOMATIC → ASYMPTOMATIC, TREATMENT, or DEAD
-        u = ss.uids((self.state == TBSL.SYMPTOMATIC) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.SYMPTOMATIC)
         if len(u):
             self.transition(u, to={
                 TBSL.ASYMPTOMATIC: self.pars.sym_asy,
@@ -730,87 +564,53 @@ class TB_LSHTM_Acute(TB_LSHTM):
                 TBSL.DEAD:         self.pars.sym_dead * self.rr_death[u],
             }, rng=self._rng_sym)
 
-        # TREATMENT → SYMPTOMATIC (failure) or TREATED (completion)
-        u = ss.uids((self.state == TBSL.TREATMENT) & (self.ti_next > ti))
+        u = ss.uids(self.state == TBSL.TREATMENT)
         if len(u):
             self.transition(u, to={
                 TBSL.SYMPTOMATIC: self.pars.fail_rate,
                 TBSL.TREATED:     self.pars.complete_rate,
             }, rng=self._rng_trt)
 
-        # CLEARED, RECOVERED, TREATED: reinfection → ACUTE (via transmission)
+        # --- Bookkeep from current state ---
 
-        # --- Phase 2: Apply transitions for agents with ti_next <= ti ---
-        uids = ss.uids(ti >= self.ti_next)
+        self.infected[:] = ~np.isin(self.state,
+            [TBSL.SUSCEPTIBLE, TBSL.CLEARED, TBSL.RECOVERED, TBSL.TREATED, TBSL.DEAD])
+        self.susceptible[:] = np.isin(self.state,
+            [TBSL.SUSCEPTIBLE, TBSL.CLEARED, TBSL.RECOVERED, TBSL.TREATED])
+        self.on_treatment[:] = (self.state == TBSL.TREATMENT)
+
+        dead = ss.uids((self.state == TBSL.DEAD) & self.sim.people.alive)
+        self.sim.people.request_death(dead)
+        self.results['new_deaths'][self.ti] = len(dead)
+        self.results['new_deaths_15+'][self.ti] = np.count_nonzero(self.sim.people.age[dead] >= 15)
+
+        self.rr_activation[:] = 1
+        self.rr_clearance[:] = 1
+        self.rr_death[:] = 1
+
+        self.rel_sus[:] = 1
+        self.rel_sus[self.state == TBSL.RECOVERED] = self.pars.rr_rec
+        self.rel_sus[self.state == TBSL.TREATED] = self.pars.rr_treat
+        self.rel_trans[:] = 1
+        self.rel_trans[self.state == TBSL.ACUTE] = self.pars.trans_acute
+        self.rel_trans[self.state == TBSL.ASYMPTOMATIC] = self.pars.trans_asymp
+
+    def start_treatment(self, uids):
+        """ACUTE or INFECTION → CLEARED; active → TREATMENT."""
         if len(uids) == 0:
             return
 
-        # Record outcomes before overwriting state
-        new_asymp_uids = uids[
-            (self.state_next[uids] == TBSL.ASYMPTOMATIC) &
-            (self.state[uids] != TBSL.SYMPTOMATIC)
-        ]
-        self.results['new_active'][ti] = len(new_asymp_uids)
-        self.results['new_active_15+'][ti] = np.count_nonzero(self.sim.people.age[new_asymp_uids] >= 15)
-
-        # Infected flag: ACUTE means still infected
-        new_inf_uids = uids[self.state_next[uids] == TBSL.ACUTE]
-        self.infected[new_inf_uids] = True
-        new_clr_uids = uids[np.isin(self.state_next[uids], [TBSL.CLEARED, TBSL.RECOVERED, TBSL.TREATED])]
-        self.infected[new_clr_uids] = False
-
-        # Apply transition
-        self.state[uids] = self.state_next[uids]
-        self.ti_next[uids] = np.inf
-        self.on_treatment[uids] = (self.state[uids] == TBSL.TREATMENT)
-
-        self.susceptible[uids] = np.isin(self.state[uids], [TBSL.CLEARED, TBSL.RECOVERED, TBSL.TREATED])
-
-        # TB deaths
-        new_death_uids = uids[self.state_next[uids] == TBSL.DEAD]
-        self.sim.people.request_death(new_death_uids)
-        self.results['new_deaths'][ti] = len(new_death_uids)
-        self.results['new_deaths_15+'][ti] = np.count_nonzero(self.sim.people.age[new_death_uids] >= 15)
-
-        # rel_sus
-        self.rel_sus[uids] = 1
-        self.rel_sus[uids[self.state[uids] == TBSL.RECOVERED]] = self.pars.rr_rec
-        self.rel_sus[uids[self.state[uids] == TBSL.TREATED]] = self.pars.rr_treat
-
-        # rel_trans: ACUTE (α alpha) and ASYMPTOMATIC (κ kappa) both infectious
-        self.rel_trans[uids] = 1
-        self.rel_trans[uids[self.state[uids] == TBSL.ACUTE]] = self.pars.trans_acute
-        self.rel_trans[uids[self.state[uids] == TBSL.ASYMPTOMATIC]] = self.pars.trans_asymp
-
-        # Reset RR multipliers (external modules set fresh values each step)
-        self.rr_activation[uids] = 1
-        self.rr_clearance[uids] = 1
-        self.rr_death[uids] = 1
-
-        return
-
-    def start_treatment(self, uids):
-        """
-        Move specified agents onto treatment (or clear); ACUTE/INFECTION → CLEARED.
-
-        Same as base but latent includes both ACUTE and INFECTION:
-
-        - ACUTE or INFECTION (latent): cleared without treatment (→ CLEARED).
-        - Active (NON_INFECTIOUS, ASYMPTOMATIC, SYMPTOMATIC): moved to TREATMENT.
-        """
-        if len(uids) == 0:
-            return 0
-
-        # ACUTE or INFECTION (latent): clear infection
-        u = uids[(self.state[uids] == TBSL.ACUTE) | (self.state[uids] == TBSL.INFECTION)]
-        self.state_next[u] = TBSL.CLEARED
-        self.ti_next[u] = self.ti
+        # ACUTE or INFECTION: clear
+        latent = uids[(self.state[uids] == TBSL.ACUTE) | (self.state[uids] == TBSL.INFECTION)]
+        self.state[latent] = TBSL.CLEARED
+        self.infected[latent] = False
+        self.susceptible[latent] = True
 
         # Active TB: put on treatment
-        u = uids[np.isin(self.state[uids], [TBSL.NON_INFECTIOUS, TBSL.ASYMPTOMATIC, TBSL.SYMPTOMATIC])]
-        self.state_next[u] = TBSL.TREATMENT
-        self.ti_next[u] = self.ti
+        active = uids[np.isin(self.state[uids], [TBSL.NON_INFECTIOUS, TBSL.ASYMPTOMATIC, TBSL.SYMPTOMATIC])]
+        self.state[active] = TBSL.TREATMENT
+        self.on_treatment[active] = True
 
-        self.results['new_notifications_15+'][self.ti]+= np.count_nonzero(self.sim.people.age[u] >= 15)
+        self.results['new_notifications_15+'][self.ti] += np.count_nonzero(self.sim.people.age[active] >= 15)
 
         return


### PR DESCRIPTION
## Summary

Major simplification of TB_LSHTM state machine. Removes the legacy deferred transition mechanism (`state_next`/`ti_next`) in favor of immediate state changes. Reduces complexity by ~240 lines.

### What changed

- **`transition()`** is now void — applies state changes immediately, no return value
- **`step()`** is a single pass: evaluate transitions → bookkeep from current state
- **All flags** (`infected`, `susceptible`, `on_treatment`) derived from `state` each step — no per-transition tracking
- **`ti_asymp`** (FloatArr) records when agents enter ASYMPTOMATIC, used by `update_results()` for `new_active`
- **`start_treatment()`** applies directly with inline bookkeeping
- Same simplification applied to **TB_LSHTM_Acute**

### States removed
- `state_next` (FloatArr)
- `ti_next` (FloatArr)

### State added
- `ti_asymp` (FloatArr, default=nan)

### Bugs fixed

| Issue | Bug | Fix |
|-------|-----|-----|
| #342 | Acute: rr_* compound-multiply (missing full reset) | rr_* reset for ALL agents at end of step() |
| #345 | step_die() leaves stale on_treatment=True | on_treatment derived from state each step |
| #346 | Acute: infected flag dead code (wrong label) | infected derived from state, no per-transition logic |
| #347 | Acute: rel_sus/rel_trans only for transitioning agents | Set for ALL agents in both classes |

Relates to #343 (new_active tracking changed to ti_asymp)

**Note**: `start_treatment()` lumps NON_INFECTIOUS with active states (ASYMPTOMATIC, SYMPTOMATIC) — may warrant a separate issue.

## Test plan

- [x] `pytest tests/test_tb_lshtm.py` — 31/31 pass
- [x] `pytest tests/test_bcg.py` — 10/10 pass
- [x] `pytest tests/test_tpt.py` — 13/13 pass
- [x] Full suite: 126 passed, 1 unrelated failure (test_compartmental ODE)