### PR TITLE
[DO NOT MERGE] Test GitHub agent for PR documentation review

### DIFF
--- a/.github/workflows/documentation-review.yaml
+++ b/.github/workflows/documentation-review.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Introduces a Copilot agent that runs on PR open/update to scan the diff and flag any existing documentation that has become stale. It dynamically discovers documentation surfaces (READMEs, docs/, notebooks, examples, config) rather than relying on a hard-coded file list.