### PR TITLE
Add treatment duration and adherence to Tx/TxDelivery

### DIFF
--- a/tbsim/interventions/diagnostics.py
+++ b/tbsim/interventions/diagnostics.py
@@ -157,12 +157,13 @@ class DxDelivery(ss.Intervention):
     """
 
     def __init__(self, product, coverage=1.0, eligibility=None, result_state='diagnosed',
-                 care_seeking_multiplier=1.0, **kwargs):
+                 care_seeking_multiplier=1.0, result_validity=None, **kwargs):
         super().__init__()
         self.product = product
         self.eligibility = eligibility
         self.result_state = result_state
         self.care_seeking_multiplier_value = care_seeking_multiplier
+        self.result_validity = result_validity
 
         self.define_pars(
             p_coverage = ss.bernoulli(p=coverage)
@@ -176,6 +177,7 @@ class DxDelivery(ss.Intervention):
             ss.BoolState('test_result', default=False),
             ss.FloatArr('care_seeking_multiplier', default=1.0),
             ss.BoolState('multiplier_applied', default=False),
+            ss.FloatArr('ti_result_set', default=np.nan),
         )
         self.update_pars(**kwargs)
         product.name = f'{self.name}_product'
@@ -205,10 +207,30 @@ class DxDelivery(ss.Intervention):
     
     def step(self):
         """ Main step method: see submethods for details. """
+        self.step_expire_results()  # Expire stale positive results
         self.step_select_eligible() # Coverage filter
         self.step_administer() # Administer diagnostic product
         self.step_update_states() # Update states based on results
         self.step_false_negatives() # Handle false negatives
+        return
+
+    def step_expire_results(self):
+        """ Reset result states that have exceeded the validity window """
+        if self.result_validity is None:
+            return
+
+        result_arr = self[self.result_state]
+        positive_uids = result_arr.uids
+        if len(positive_uids) == 0:
+            return
+
+        # Convert validity from days to timesteps
+        validity_steps = float(self.result_validity) / self.sim.t.dt.days
+        ti_set = self.ti_result_set[positive_uids]
+        expired = positive_uids[~np.isnan(ti_set) & (self.ti >= ti_set + validity_steps)]
+        if len(expired) > 0:
+            result_arr[expired] = False
+            self.tested[expired] = False
         return
     
     def step_select_eligible(self):
@@ -230,13 +252,14 @@ class DxDelivery(ss.Intervention):
         return results
     
     def step_update_states(self):
-        """ Update states associated with """
+        """ Update states associated with diagnostic results """
         selected = self._selected
         pos_uids = self._pos
 
-        # Set result state
+        # Set result state and record when it was set
         result_arr = self[self.result_state]
         result_arr[pos_uids] = True
+        self.ti_result_set[pos_uids] = self.ti
 
         # Update tracking states
         self.tested[selected] = True

--- a/tbsim/interventions/interventions.py
+++ b/tbsim/interventions/interventions.py
@@ -95,24 +95,23 @@ class TBProductRoutine(ss.Intervention):
         Routine delivery step:
 
         1. Check date window.
-        2. Product handles internal phase transitions (``update_roster``).
-        3. Find and deliver to newly eligible agents.
-        4. Product applies ``rr_*`` modifiers for all currently protected.
+        2. Product handles internal phase transitions (``update_roster``) - even outside of date window
+        3. Find and deliver to newly eligible agents - only during date window
+        4. Product applies ``rr_*`` modifiers for all currently protected - even outside of date window
         """
         now = self.sim.now
         now_date = now.date() if hasattr(now, 'date') else now
-        if now_date < self.pars.start.date() or now_date > self.pars.stop.date():
-            return
-
+        
         # Product-internal transitions (expire protection, complete treatment, etc.)
         self.product.update_roster()
 
-        # Deliver to newly eligible
-        eligible = self.check_eligibility()
-        if len(eligible) > 0:
-            self.initiated[eligible] = True
-            self.ti_initiated[eligible] = self.ti
-            self.product.administer(self.sim.people, eligible)
+        # Deliver to newly eligible - only during date window
+        if now_date >= self.pars.start.date() and now_date <= self.pars.stop.date():
+            eligible = self.check_eligibility()
+            if len(eligible) > 0:
+                self.initiated[eligible] = True
+                self.ti_initiated[eligible] = self.ti
+                self.product.administer(self.sim.people, eligible)
 
         # Apply modifiers for all currently protected
         self.product.apply_protection()

--- a/tbsim/interventions/interventions.py
+++ b/tbsim/interventions/interventions.py
@@ -24,7 +24,7 @@ class TBProductRoutine(ss.Intervention):
     Args:
         product (ss.Vx): The vaccine/treatment product.
         coverage (ss.bernoulli): Fraction of eligible individuals who accept (applied once per person).
-        start / stop (ss.date): Campaign window.
+        start / stop (ss.date): Campaign window (defaults to sim start/stop if not provided).
         age_range (list or None): ``[min_age, max_age]`` filter, or ``None`` to skip.
         eligible_states (list or None): List of disease-state values (e.g. ``[TBS.INFECTION]``) to filter on,
             or ``None`` to skip.
@@ -37,8 +37,8 @@ class TBProductRoutine(ss.Intervention):
         super().__init__(**kwargs)
 
         self.define_pars(
-            start=ss.date('1900-01-01'),
-            stop=ss.date('2100-12-31'),
+            start=None,
+            stop=None,
             coverage=ss.bernoulli(p=0.5),
             age_range=None,
             eligible_states=None,
@@ -52,6 +52,15 @@ class TBProductRoutine(ss.Intervention):
             ss.BoolArr('initiated', default=False),
             ss.FloatArr('ti_initiated'),
         )
+        return
+
+    def init_pre(self, sim):
+        """Fill in start/stop from sim timeline if not explicitly set."""
+        if self.pars.start is None:
+            self.pars.start = sim.t.start
+        if self.pars.stop is None:
+            self.pars.stop = sim.t.stop
+        super().init_pre(sim)
         return
 
     def check_eligibility(self):

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -52,27 +52,14 @@ class TPTTx(ss.Product):
     MECH_STERILIZE = 1
     MECH_SUPPRESS = 2
 
-    def __init__(self, pars=None, p_sterilization=0.0, p_suppression=1.0, **kwargs):
+    def __init__(self, pars=None, **kwargs):
         """Initialize TPT product with mechanism probabilities and efficacy parameters."""
         super().__init__(**kwargs)
 
-        # Allow mechanism probabilities via pars dict or constructor args
-        pars = dict(pars) if pars else {}
-        p_sterilization = pars.pop('p_sterilization', p_sterilization)
-        p_suppression   = pars.pop('p_suppression', p_suppression)
-
-        # Validate mechanism probabilities
-        p_neither = 1.0 - p_sterilization - p_suppression
-        if p_neither < -1e-10:
-            raise ValueError(f"p_sterilization ({p_sterilization}) + p_suppression ({p_suppression}) must be <= 1.0")
-        p_neither = max(0.0, p_neither)  # Clamp rounding errors
-
         self.define_pars(
             disease='tb',
-            p_sterilization=p_sterilization,
-            p_suppression=p_suppression,
-            mechanism_dist=ss.choice(a=[self.MECH_NONE, self.MECH_STERILIZE, self.MECH_SUPPRESS],
-                                     p=[p_neither, p_sterilization, p_suppression]),
+            p_sterilization=0.0,
+            p_suppression=1.0,
             dur_treatment=ss.constant(v=ss.months(3)),
             dur_protection=ss.constant(v=ss.years(2)),
             activation_modifier=ss.uniform(0.3, 0.5),
@@ -81,6 +68,16 @@ class TPTTx(ss.Product):
             exclude_on_treatment=True,
         )
         self.update_pars(pars)
+
+        # Build mechanism_dist from final p_sterilization / p_suppression
+        p_sterilization = self.pars.p_sterilization
+        p_suppression   = self.pars.p_suppression
+        p_neither = 1.0 - p_sterilization - p_suppression
+        if p_neither < -1e-10:
+            raise ValueError(f"p_sterilization ({p_sterilization}) + p_suppression ({p_suppression}) must be <= 1.0")
+        p_neither = max(0.0, p_neither)  # Clamp rounding errors
+        self.pars.mechanism_dist = ss.choice(a=[self.MECH_NONE, self.MECH_STERILIZE, self.MECH_SUPPRESS],
+                                             p=[p_neither, p_sterilization, p_suppression])
 
         self.define_states(
             ss.IntArr('tpt_mechanism', default=self.MECH_NONE),

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -24,22 +24,18 @@ class TPTTx(ss.Product):
     """
     TPT treatment product with sterilization and suppression mechanisms.
 
-    Each agent receiving TPT is assigned one of three outcomes via a
-    multinomial draw (``ss.choice``):
+    TPT efficacy is modeled in two stages:
 
-    - **Sterilization** (``p_sterilization``): infection is cleared at
-      treatment completion (INFECTION → CLEARED). Only effective if the
-      agent is still in INFECTION state when treatment ends.
-    - **Suppression** (``p_suppression``): residual risk reduction via
-      ``rr_*`` modifiers during a post-treatment protection window.
-    - **Neither** (remainder): no benefit (e.g., non-adherent).
-
-    These are mutually exclusive; no agent gets both.
+    1. ``efficacy`` determines whether TPT works at all for a given agent.
+    2. Among efficacious agents, ``p_sterilize`` determines who gets
+       sterilization (infection cleared) vs suppression (risk reduction
+       via ``rr_*`` modifiers). These are mutually exclusive.
 
     Args:
         disease (str): Key of the disease module to target (default ``'tb'``).
-        p_sterilization (float): Probability of sterilization benefit (default 0.0).
-        p_suppression (float): Probability of suppression benefit (default 1.0).
+        efficacy (ss.bernoulli): Probability that TPT works (default 0.6).
+        p_sterilize (ss.bernoulli): Among efficacious agents, probability of
+            sterilization vs suppression (default 0.0 = all suppression).
         dur_treatment (ss.Dist): Duration of the antibiotic course (default 3 months).
         dur_protection (ss.Dist): Duration of post-treatment protection (default 2 years).
         activation_modifier / clearance_modifier / death_modifier (ss.Dist):
@@ -58,8 +54,8 @@ class TPTTx(ss.Product):
 
         self.define_pars(
             disease='tb',
-            p_sterilization=0.0,
-            p_suppression=1.0,
+            efficacy=ss.bernoulli(p=0.6),
+            p_sterilize=ss.bernoulli(p=0.0),
             dur_treatment=ss.constant(v=ss.months(3)),
             dur_protection=ss.constant(v=ss.years(2)),
             activation_modifier=ss.uniform(0.3, 0.5),
@@ -68,16 +64,6 @@ class TPTTx(ss.Product):
             exclude_on_treatment=True,
         )
         self.update_pars(pars)
-
-        # Build mechanism_dist from final p_sterilization / p_suppression
-        p_sterilization = self.pars.p_sterilization
-        p_suppression   = self.pars.p_suppression
-        p_neither = 1.0 - p_sterilization - p_suppression
-        if p_neither < -1e-10:
-            raise ValueError(f"p_sterilization ({p_sterilization}) + p_suppression ({p_suppression}) must be <= 1.0")
-        p_neither = max(0.0, p_neither)  # Clamp rounding errors
-        self.pars.mechanism_dist = ss.choice(a=[self.MECH_NONE, self.MECH_STERILIZE, self.MECH_SUPPRESS],
-                                             p=[p_neither, p_sterilization, p_suppression])
 
         self.define_states(
             ss.IntArr('tpt_mechanism', default=self.MECH_NONE),
@@ -118,17 +104,19 @@ class TPTTx(ss.Product):
         if len(uids) == 0:
             return ss.uids()
 
-        # Roll mechanism assignment
-        mechanism = self.pars.mechanism_dist.rvs(uids)
-        self.tpt_mechanism[uids] = mechanism
+        # Draw 1: is TPT effective?
+        effective, ineffective = self.pars.efficacy.filter(uids, both=True)
+        self.tpt_mechanism[ineffective] = self.MECH_NONE
+
+        # Draw 2: among effective agents, sterilization or suppression?
+        sterilize, suppress = self.pars.p_sterilize.filter(effective, both=True)
+        self.tpt_mechanism[sterilize] = self.MECH_STERILIZE
+        self.tpt_mechanism[suppress]  = self.MECH_SUPPRESS
 
         # Schedule treatment duration for all agents (ti_protection_starts is used
         # by update_roster to detect treatment completion, regardless of mechanism)
         dur_tx = self.pars.dur_treatment.rvs(uids)
         self.ti_protection_starts[uids] = self.ti + dur_tx
-
-        # Suppression agents also need protection window and rr_* modifiers
-        suppress = uids[mechanism == self.MECH_SUPPRESS]
         if len(suppress) > 0:
             dur_prot = self.pars.dur_protection.rvs(suppress)
             self.ti_protection_expires[suppress] = self.ti_protection_starts[suppress] + dur_prot

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -1,9 +1,11 @@
 """
 Tuberculosis Preventive Therapy (TPT): Product + Delivery.
 
-``TPTTx``         — treatment product  (biological effect, per-agent state)
-``TPTSimple``     — simple delivery    (targets latently infected by default)
-``TPTHousehold``  — household contact tracing delivery
+``TPTTx``                    — treatment product  (biological effect, per-agent state)
+``TPTSimple``                — simple delivery    (targets latently infected by default)
+``TPTHousehold``             — household contact tracing delivery (legacy)
+``HouseholdContactTracing``  — identifies household contacts of new treatment cases
+``TPTDelivery``              — delivers TPT to screened contacts without active disease
 """
 
 import numpy as np
@@ -11,7 +13,7 @@ import starsim as ss
 from .interventions import TBProductRoutine
 from ..tb import TBS
 
-__all__ = ['TPTTx', 'TPTSimple', 'TPTHousehold']
+__all__ = ['TPTTx', 'TPTSimple', 'TPTHousehold', 'HouseholdContactTracing', 'TPTDelivery']
 
 
 # ---------------------------------------------------------------------------
@@ -79,8 +81,10 @@ class TPTTx(ss.Product):
             tb = self.sim.diseases[self.pars.disease]
             uids = uids[~tb.on_treatment[uids]]
 
-        # Skip agents already protected (don't restart their clock)
+        # Skip agents already protected or in treatment phase (don't restart their clock)
         uids = uids[~self.tpt_protected[uids]]
+        already_initiated = ~np.isnan(self.ti_protection_starts[uids])
+        uids = uids[~already_initiated]
 
         if len(uids) == 0:
             return ss.uids()
@@ -272,4 +276,194 @@ class TPTHousehold(TBProductRoutine):
     def shrink(self):
         """ Delete link to household net """
         self.hh_net = None
+        return
+
+
+# ---------------------------------------------------------------------------
+# Composable household contact tracing + TPT delivery
+# ---------------------------------------------------------------------------
+
+class HouseholdContactTracing(ss.Intervention):
+    """
+    Identifies household contacts of agents who newly start TB treatment.
+
+    Sets ``contact_identified=True`` on household members of followed-up
+    index cases. Downstream interventions (e.g. ``DxDelivery`` for screening,
+    ``TPTDelivery`` for preventive therapy) read this flag.
+
+    Requires a household network with ``household_ids`` (e.g. ``ss.HouseholdNet``).
+
+    Args:
+        coverage (float): Probability that a given index case's household is
+            followed up (per-index-case Bernoulli). Default 0.8.
+        disease (str): Key of the TB disease module. Default ``'tb'``.
+    """
+
+    def __init__(self, coverage=0.8, disease='tb', **kwargs):
+        super().__init__(**kwargs)
+        self.disease = disease
+        self.define_pars(
+            coverage = ss.bernoulli(p=coverage),
+        )
+        self.define_states(
+            ss.BoolArr('prev_on_treatment', default=False),
+            ss.BoolArr('contact_identified', default=False),
+            ss.FloatArr('ti_contact_identified', default=np.nan),
+        )
+        self.hh_net = None
+        return
+
+    def find_household_net(self):
+        """Find the network that has ``household_ids``."""
+        for net in self.sim.networks.values():
+            if hasattr(net, 'household_ids'):
+                return net
+        raise ValueError("No household network with household_ids found in sim")
+
+    def init_results(self):
+        super().init_results()
+        self.define_results(
+            ss.Result('n_contacts_identified', dtype=int),
+            ss.Result('n_index_followed_up', dtype=int),
+        )
+        return
+
+    def step(self):
+        """Detect new treatment starts, trace household contacts, set flags."""
+        tb = self.sim.diseases[self.disease]
+        if self.hh_net is None:
+            self.hh_net = self.find_household_net()
+        hh_net = self.hh_net
+
+        # 1. Detect NEW treatment starts (on_treatment: False → True)
+        newly_on_treatment = (tb.on_treatment & ~self.prev_on_treatment).uids
+        self.prev_on_treatment[:] = tb.on_treatment
+
+        self._n_followed = 0
+        self._n_contacts = 0
+
+        if len(newly_on_treatment) == 0:
+            return
+
+        # 2. Coverage: per index case (does health system follow up?)
+        followed_up = self.pars.coverage.filter(newly_on_treatment)
+        if len(followed_up) == 0:
+            return
+        self._n_followed = len(followed_up)
+
+        # 3. Find their household IDs
+        hhids = np.asarray(hh_net.household_ids[followed_up])
+        target_hhids = np.unique(hhids[~np.isnan(hhids)])
+
+        if len(target_hhids) == 0:
+            return
+
+        # 4. Find household contacts (excluding index cases)
+        all_hh = np.isin(np.asarray(hh_net.household_ids), target_hhids)
+        contacts = ss.uids(all_hh)
+        contacts = contacts.remove(followed_up)
+
+        # 5. Filter to alive agents only
+        contacts = contacts.intersect(self.sim.people.alive.uids)
+
+        if len(contacts) == 0:
+            return
+
+        # 6. Set contact_identified flag
+        self.contact_identified[contacts] = True
+        self.ti_contact_identified[contacts] = self.ti
+        self._n_contacts = len(contacts)
+        return
+
+    def update_results(self):
+        self.results.n_contacts_identified[self.ti] = self._n_contacts
+        self.results.n_index_followed_up[self.ti] = self._n_followed
+        return
+
+    def shrink(self):
+        self.hh_net = None
+        return
+
+
+class TPTDelivery(ss.Intervention):
+    """
+    Delivers TPT to household contacts who were screened and found NOT to
+    have active disease.
+
+    Reads flags from ``HouseholdContactTracing`` (``contact_identified``) and
+    a screening ``DxDelivery`` (``tested`` and result state) to determine
+    eligibility: contacts who were identified, screened, and not diagnosed
+    with active TB.
+
+    Args:
+        product (TPTTx): The TPT treatment product. Created automatically if not provided.
+        contact_tracing (str): Name of the ``HouseholdContactTracing`` intervention.
+            Default ``'householdcontacttracing'``.
+        contact_screen (str): Name of the screening ``DxDelivery`` intervention.
+            Default ``'contact_screen'``.
+        result_state (str): The result state name on the screening DxDelivery
+            that indicates a positive (active TB) result. Default ``'diagnosed'``.
+    """
+
+    def __init__(self, product=None, contact_tracing='householdcontacttracing',
+                 contact_screen='contact_screen', result_state='diagnosed', **kwargs):
+        super().__init__(**kwargs)
+        self.product = product if product is not None else TPTTx()
+        self._ct_name = contact_tracing
+        self._cs_name = contact_screen
+        self._result_state = result_state
+        self._ct = None
+        self._cs = None
+        self.product.name = f'{self.name}_product'
+        return
+
+    def init_post(self):
+        super().init_post()
+        # Resolve references to other interventions
+        self._ct = self.sim.interventions[self._ct_name]
+        self._cs = self.sim.interventions[self._cs_name]
+
+    def init_results(self):
+        super().init_results()
+        self.define_results(
+            ss.Result('n_tpt_initiated', dtype=int),
+            ss.Result('n_protected', dtype=int),
+        )
+        return
+
+    def _get_eligible(self):
+        """Get contacts who were identified, screened, and not diagnosed with active TB."""
+        ct = self._ct
+        cs = self._cs
+        ppl = self.sim.people
+
+        # Must be: contact_identified AND screened (tested) AND NOT diagnosed AND alive
+        result_arr = cs[self._result_state]
+        eligible = (ct.contact_identified & cs.tested & ~result_arr & ppl.alive).uids
+        return eligible
+
+    def step(self):
+        """Deliver TPT to eligible contacts; manage product lifecycle."""
+        # Product-internal transitions (expire protection, complete treatment)
+        self.product.update_roster()
+
+        # Find and deliver to eligible contacts
+        eligible = self._get_eligible()
+        self._n_initiated = 0
+        if len(eligible) > 0:
+            started = self.product.administer(self.sim.people, eligible)
+            self._n_initiated = len(started)
+
+        # Apply rr_* modifiers for all currently protected
+        self.product.apply_protection()
+        return
+
+    def update_results(self):
+        self.results.n_tpt_initiated[self.ti] = self._n_initiated
+        self.results.n_protected[self.ti] = np.count_nonzero(self.product.tpt_protected)
+        return
+
+    def shrink(self):
+        self._ct = None
+        self._cs = None
         return

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -56,6 +56,11 @@ class TPTTx(ss.Product):
         """Initialize TPT product with mechanism probabilities and efficacy parameters."""
         super().__init__(**kwargs)
 
+        # Allow mechanism probabilities via pars dict or constructor args
+        pars = dict(pars) if pars else {}
+        p_sterilization = pars.pop('p_sterilization', p_sterilization)
+        p_suppression   = pars.pop('p_suppression', p_suppression)
+
         # Validate mechanism probabilities
         p_neither = 1.0 - p_sterilization - p_suppression
         if p_neither < -1e-10:
@@ -80,7 +85,7 @@ class TPTTx(ss.Product):
         self.define_states(
             ss.IntArr('tpt_mechanism', default=self.MECH_NONE),
             ss.BoolArr('tpt_protected', default=False),
-            ss.BoolArr('tpt_sterilized', default=False),
+            ss.BoolArr('tpt_resolved', default=False),
             ss.FloatArr('ti_protection_starts'),
             ss.FloatArr('ti_protection_expires'),
             ss.FloatArr('tpt_activation_modifier_applied'),
@@ -120,7 +125,8 @@ class TPTTx(ss.Product):
         mechanism = self.pars.mechanism_dist.rvs(uids)
         self.tpt_mechanism[uids] = mechanism
 
-        # Schedule treatment duration for all agents
+        # Schedule treatment duration for all agents (ti_protection_starts is used
+        # by update_roster to detect treatment completion, regardless of mechanism)
         dur_tx = self.pars.dur_treatment.rvs(uids)
         self.ti_protection_starts[uids] = self.ti + dur_tx
 
@@ -147,7 +153,7 @@ class TPTTx(ss.Product):
         Also expires protection for suppression agents past their window.
         """
         # Find agents whose treatment just completed
-        not_yet_resolved = (~self.tpt_protected & ~self.tpt_sterilized).uids
+        not_yet_resolved = (~self.tpt_protected & ~self.tpt_resolved).uids
         if len(not_yet_resolved) > 0:
             starts = self.ti_protection_starts[not_yet_resolved]
             ready = not_yet_resolved[~np.isnan(starts) & (self.ti >= starts)]
@@ -165,6 +171,11 @@ class TPTTx(ss.Product):
                 if len(suppress_uids) > 0:
                     self.tpt_protected[suppress_uids] = True
 
+                # Neither: mark as resolved so they aren't re-checked each step
+                neither_uids = ready[mechs == self.MECH_NONE]
+                if len(neither_uids) > 0:
+                    self.tpt_resolved[neither_uids] = True
+
         # Expire protection for suppression agents
         protected_uids = self.tpt_protected.uids
         if len(protected_uids) > 0:
@@ -181,7 +192,7 @@ class TPTTx(ss.Product):
         # Only sterilize agents still latently infected
         still_infected = uids[tb.state[uids] == TBS.INFECTION]
         if len(still_infected) == 0:
-            self.tpt_sterilized[uids] = True  # Mark as resolved even if no effect
+            self.tpt_resolved[uids] = True  # Mark as resolved even if no effect
             return
 
         # Clear infection (same pattern as TxDelivery.step_start_treatment)
@@ -192,7 +203,7 @@ class TPTTx(ss.Product):
         tb.infected[still_infected] = False
         tb.susceptible[still_infected] = True
 
-        self.tpt_sterilized[uids] = True
+        self.tpt_resolved[uids] = True
         return
 
     def apply_protection(self):

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -63,8 +63,8 @@ class TPTTx(ss.Product):
             dur_treatment=ss.constant(v=ss.months(3)),
             dur_protection=ss.constant(v=ss.years(2)),
             activation_modifier=ss.uniform(0.3, 0.5),
-            clearance_modifier=ss.uniform(1.2, 1.4),
-            death_modifier=ss.uniform(0.1, 0.3),
+            clearance_modifier=ss.uniform(1.0, 1.0),
+            death_modifier=ss.uniform(1.0, 1.0),
             exclude_on_treatment=True,
         )
         self.update_pars(pars)

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -22,27 +22,52 @@ __all__ = ['TPTTx', 'TPTSimple', 'TPTHousehold', 'HouseholdContactTracing', 'TPT
 
 class TPTTx(ss.Product):
     """
-    TPT treatment product.
+    TPT treatment product with sterilization and suppression mechanisms.
 
-    Models a two-phase intervention: a **treatment phase** (antibiotic course)
-    followed by a **protection phase** (residual risk reduction via ``rr_*``
-    modifiers).  During treatment, no protection is applied; after treatment
-    completes, ``rr_activation``, ``rr_clearance``, and ``rr_death`` are
-    modified each step until protection expires.
+    Each agent receiving TPT is assigned one of three outcomes via a
+    multinomial draw (``ss.choice``):
+
+    - **Sterilization** (``p_sterilization``): infection is cleared at
+      treatment completion (INFECTION → CLEARED). Only effective if the
+      agent is still in INFECTION state when treatment ends.
+    - **Suppression** (``p_suppression``): residual risk reduction via
+      ``rr_*`` modifiers during a post-treatment protection window.
+    - **Neither** (remainder): no benefit (e.g., non-adherent).
+
+    These are mutually exclusive; no agent gets both.
 
     Args:
         disease (str): Key of the disease module to target (default ``'tb'``).
+        p_sterilization (float): Probability of sterilization benefit (default 0.0).
+        p_suppression (float): Probability of suppression benefit (default 1.0).
         dur_treatment (ss.Dist): Duration of the antibiotic course (default 3 months).
         dur_protection (ss.Dist): Duration of post-treatment protection (default 2 years).
-        activation_modifier / clearance_modifier / death_modifier (ss.Dist): Per-individual risk-modifier distributions.
+        activation_modifier / clearance_modifier / death_modifier (ss.Dist):
+            Per-individual risk-modifier distributions (suppression only).
         exclude_on_treatment (bool): If True, skip agents currently on TB treatment (default True).
     """
 
-    def __init__(self, pars=None, **kwargs):
-        """Initialize TPT product with default treatment duration and efficacy parameters."""
+    # Mechanism constants
+    MECH_NONE = 0
+    MECH_STERILIZE = 1
+    MECH_SUPPRESS = 2
+
+    def __init__(self, pars=None, p_sterilization=0.0, p_suppression=1.0, **kwargs):
+        """Initialize TPT product with mechanism probabilities and efficacy parameters."""
         super().__init__(**kwargs)
+
+        # Validate mechanism probabilities
+        p_neither = 1.0 - p_sterilization - p_suppression
+        if p_neither < -1e-10:
+            raise ValueError(f"p_sterilization ({p_sterilization}) + p_suppression ({p_suppression}) must be <= 1.0")
+        p_neither = max(0.0, p_neither)  # Clamp rounding errors
+
         self.define_pars(
             disease='tb',
+            p_sterilization=p_sterilization,
+            p_suppression=p_suppression,
+            mechanism_dist=ss.choice(a=[self.MECH_NONE, self.MECH_STERILIZE, self.MECH_SUPPRESS],
+                                     p=[p_neither, p_sterilization, p_suppression]),
             dur_treatment=ss.constant(v=ss.months(3)),
             dur_protection=ss.constant(v=ss.years(2)),
             activation_modifier=ss.uniform(0.3, 0.5),
@@ -53,7 +78,9 @@ class TPTTx(ss.Product):
         self.update_pars(pars)
 
         self.define_states(
+            ss.IntArr('tpt_mechanism', default=self.MECH_NONE),
             ss.BoolArr('tpt_protected', default=False),
+            ss.BoolArr('tpt_sterilized', default=False),
             ss.FloatArr('ti_protection_starts'),
             ss.FloatArr('ti_protection_expires'),
             ss.FloatArr('tpt_activation_modifier_applied'),
@@ -66,9 +93,9 @@ class TPTTx(ss.Product):
         """
         Start TPT for *uids*.
 
-        Filters out ineligible agents (already on TB treatment, already
-        protected), then samples per-agent modifiers and schedules the
-        protection window.
+        Filters out ineligible agents, rolls mechanism assignment
+        (sterilization / suppression / neither), schedules treatment
+        duration, and samples rr_* modifiers for suppression agents.
 
         Returns:
             ss.uids: UIDs of agents who actually started TPT.
@@ -89,33 +116,56 @@ class TPTTx(ss.Product):
         if len(uids) == 0:
             return ss.uids()
 
+        # Roll mechanism assignment
+        mechanism = self.pars.mechanism_dist.rvs(uids)
+        self.tpt_mechanism[uids] = mechanism
+
+        # Schedule treatment duration for all agents
         dur_tx = self.pars.dur_treatment.rvs(uids)
-        dur_prot = self.pars.dur_protection.rvs(uids)
-
         self.ti_protection_starts[uids] = self.ti + dur_tx
-        self.ti_protection_expires[uids] = self.ti + dur_tx + dur_prot
 
-        self.tpt_activation_modifier_applied[uids] = self.pars.activation_modifier.rvs(uids)
-        self.tpt_clearance_modifier_applied[uids] = self.pars.clearance_modifier.rvs(uids)
-        self.tpt_death_modifier_applied[uids] = self.pars.death_modifier.rvs(uids)
+        # Suppression agents also need protection window and rr_* modifiers
+        suppress = uids[mechanism == self.MECH_SUPPRESS]
+        if len(suppress) > 0:
+            dur_prot = self.pars.dur_protection.rvs(suppress)
+            self.ti_protection_expires[suppress] = self.ti_protection_starts[suppress] + dur_prot
+            self.tpt_activation_modifier_applied[suppress] = self.pars.activation_modifier.rvs(suppress)
+            self.tpt_clearance_modifier_applied[suppress] = self.pars.clearance_modifier.rvs(suppress)
+            self.tpt_death_modifier_applied[suppress] = self.pars.death_modifier.rvs(suppress)
 
         return uids
 
     def update_roster(self):
         """
-        Start protection for agents whose treatment completed;
-        expire protection for agents past their expiry time.
-        """
-        # Start protection for agents whose treatment just completed
-        not_yet_protected = (~self.tpt_protected).uids
-        if len(not_yet_protected) > 0:
-            starts = self.ti_protection_starts[not_yet_protected]
-            ready = not_yet_protected[
-                ~np.isnan(starts) & (self.ti >= starts)
-            ]
-            self.tpt_protected[ready] = True
+        Handle treatment completion by mechanism:
 
-        # Expire protection
+        - **Sterilization**: clear infection (INFECTION → CLEARED) if agent
+          is still latently infected.
+        - **Suppression**: start rr_* protection phase.
+        - **Neither**: no action.
+
+        Also expires protection for suppression agents past their window.
+        """
+        # Find agents whose treatment just completed
+        not_yet_resolved = (~self.tpt_protected & ~self.tpt_sterilized).uids
+        if len(not_yet_resolved) > 0:
+            starts = self.ti_protection_starts[not_yet_resolved]
+            ready = not_yet_resolved[~np.isnan(starts) & (self.ti >= starts)]
+
+            if len(ready) > 0:
+                mechs = self.tpt_mechanism[ready]
+
+                # Sterilization: clear infection if still in INFECTION state
+                sterilize_uids = ready[mechs == self.MECH_STERILIZE]
+                if len(sterilize_uids) > 0:
+                    self._apply_sterilization(sterilize_uids)
+
+                # Suppression: start protection phase
+                suppress_uids = ready[mechs == self.MECH_SUPPRESS]
+                if len(suppress_uids) > 0:
+                    self.tpt_protected[suppress_uids] = True
+
+        # Expire protection for suppression agents
         protected_uids = self.tpt_protected.uids
         if len(protected_uids) > 0:
             expired = protected_uids[
@@ -124,8 +174,29 @@ class TPTTx(ss.Product):
             self.tpt_protected[expired] = False
         return
 
+    def _apply_sterilization(self, uids):
+        """Clear infection for sterilization agents still in INFECTION state."""
+        tb = self.sim.diseases[self.pars.disease]
+
+        # Only sterilize agents still latently infected
+        still_infected = uids[tb.state[uids] == TBS.INFECTION]
+        if len(still_infected) == 0:
+            self.tpt_sterilized[uids] = True  # Mark as resolved even if no effect
+            return
+
+        # Clear infection (same pattern as TxDelivery.step_start_treatment)
+        tb.state[still_infected] = TBS.CLEARED
+        tb.rr_reinfection[still_infected] = tb.pars.rr_reinfection_cleared
+        if tb.pars.dur_reinfection_protection is not None:
+            tb.ti_rr_reinfection_wane[still_infected] = self.ti + tb.pars.dur_reinfection_protection.rvs(still_infected)
+        tb.infected[still_infected] = False
+        tb.susceptible[still_infected] = True
+
+        self.tpt_sterilized[uids] = True
+        return
+
     def apply_protection(self):
-        """Multiply ``rr_*`` arrays for all currently protected agents."""
+        """Multiply ``rr_*`` arrays for all currently protected (suppression) agents."""
         protected = self.tpt_protected.uids
         if len(protected) > 0:
             tb = self.sim.diseases[self.pars.disease]

--- a/tbsim/interventions/treatments.py
+++ b/tbsim/interventions/treatments.py
@@ -11,13 +11,13 @@ __all__ = ['drug_params', 'Tx', 'TxMulti', 'DOTS', 'DOTSImproved', 'FirstLine', 
 # Drug parameters keyed by drug type name.
 # Each entry maps to a dict of clinical parameters.
 drug_params = dict(
-    dots                = dict(cure_prob=0.85, inactivation_rate=0.10, resistance_rate=0.02, relapse_rate=0.05, mortality_rate=0.80, duration=180, adherence_rate=0.85, cost_per_course=100),
-    dots_improved       = dict(cure_prob=0.90, inactivation_rate=0.08, resistance_rate=0.015, relapse_rate=0.03, mortality_rate=0.85, duration=180, adherence_rate=0.90, cost_per_course=150),
-    empiric_treatment   = dict(cure_prob=0.70, inactivation_rate=0.15, resistance_rate=0.05, relapse_rate=0.10, mortality_rate=0.60, duration=90,  adherence_rate=0.75, cost_per_course=80),
-    first_line_combo    = dict(cure_prob=0.95, inactivation_rate=0.05, resistance_rate=0.01, relapse_rate=0.02, mortality_rate=0.90, duration=120, adherence_rate=0.88, cost_per_course=200),
-    second_line_combo   = dict(cure_prob=0.75, inactivation_rate=0.12, resistance_rate=0.03, relapse_rate=0.08, mortality_rate=0.70, duration=240, adherence_rate=0.80, cost_per_course=500),
-    third_line_combo    = dict(cure_prob=0.60, inactivation_rate=0.20, resistance_rate=0.08, relapse_rate=0.15, mortality_rate=0.50, duration=360, adherence_rate=0.70, cost_per_course=1000),
-    latent_treatment    = dict(cure_prob=0.90, inactivation_rate=0.02, resistance_rate=0.005, relapse_rate=0.01, mortality_rate=0.95, duration=90,  adherence_rate=0.85, cost_per_course=50),
+    dots                = dict(cure_prob=0.85, inactivation_rate=0.10, resistance_rate=0.02, relapse_rate=0.05, mortality_rate=0.80, duration=ss.days(180), adherence_rate=0.85, cost_per_course=100),
+    dots_improved       = dict(cure_prob=0.90, inactivation_rate=0.08, resistance_rate=0.015, relapse_rate=0.03, mortality_rate=0.85, duration=ss.days(180), adherence_rate=0.90, cost_per_course=150),
+    empiric_treatment   = dict(cure_prob=0.70, inactivation_rate=0.15, resistance_rate=0.05, relapse_rate=0.10, mortality_rate=0.60, duration=ss.days(90),  adherence_rate=0.75, cost_per_course=80),
+    first_line_combo    = dict(cure_prob=0.95, inactivation_rate=0.05, resistance_rate=0.01, relapse_rate=0.02, mortality_rate=0.90, duration=ss.days(120), adherence_rate=0.88, cost_per_course=200),
+    second_line_combo   = dict(cure_prob=0.75, inactivation_rate=0.12, resistance_rate=0.03, relapse_rate=0.08, mortality_rate=0.70, duration=ss.days(240), adherence_rate=0.80, cost_per_course=500),
+    third_line_combo    = dict(cure_prob=0.60, inactivation_rate=0.20, resistance_rate=0.08, relapse_rate=0.15, mortality_rate=0.50, duration=ss.days(360), adherence_rate=0.70, cost_per_course=1000),
+    latent_treatment    = dict(cure_prob=0.90, inactivation_rate=0.02, resistance_rate=0.005, relapse_rate=0.01, mortality_rate=0.95, duration=ss.days(90),  adherence_rate=0.85, cost_per_course=50),
 )
 
 
@@ -38,10 +38,10 @@ class Tx(ss.Product):
         if drug_type is not None:
             dp = drug_params[drug_type]
             efficacy = dp['cure_prob']
-            dur_treatment = dur_treatment or ss.constant(v=dp['duration'])
+            dur_treatment = dur_treatment or ss.constant(v=dp['duration'].days)
             adherence = dp['adherence_rate']
         else:
-            dur_treatment = dur_treatment or ss.constant(v=180)
+            dur_treatment = dur_treatment or ss.constant(v=ss.days(180).days)
 
         self.define_pars(
             p_adherence = ss.bernoulli(adherence),
@@ -216,10 +216,11 @@ class TxDelivery(ss.Intervention):
         tb.on_treatment[active] = True
         tb.results['new_notifications_15+'][tb.ti] += np.count_nonzero(self.sim.people.age[active] >= 15)
 
-        # Record treatment timing
-        dur = self.product.pars.dur_treatment.rvs(active)
+        # Record treatment timing (convert dur from days to timesteps)
+        dur_days = self.product.pars.dur_treatment.rvs(active)
+        dur_steps = dur_days / self.sim.t.dt.days
         self.ti_treatment_start[active] = self.ti
-        self.ti_treatment_end[active] = self.ti + dur
+        self.ti_treatment_end[active] = self.ti + dur_steps
         self.n_times_treated[active] += 1
 
         # Pre-roll outcomes (stored as pending, resolved when treatment completes)

--- a/tbsim/interventions/treatments.py
+++ b/tbsim/interventions/treatments.py
@@ -61,6 +61,8 @@ class Tx(ss.Product):
         Returns:
             dict with 'success' and 'failure' UIDs.
         """
+        # TODO: non-adherent agents currently get zero efficacy; consider partial
+        # efficacy for incomplete courses (e.g. scaled by fraction of course completed)
         adherent, non_adherent = self.pars.p_adherence.filter(uids, both=True)
         success_uids, adherent_fail = self.pars.p_success.filter(adherent, both=True)
         failure_uids = ss.uids.cat([non_adherent, adherent_fail])

--- a/tbsim/interventions/treatments.py
+++ b/tbsim/interventions/treatments.py
@@ -23,34 +23,47 @@ drug_params = dict(
 
 class Tx(ss.Product):
     """
-    TB treatment product that encapsulates drug efficacy.
+    TB treatment product that encapsulates drug efficacy, duration, and adherence.
 
     Args:
-        efficacy: Probability of treatment success (0-1). Default 0.85.
-        drug_type: If provided (e.g. 'dots', 'first_line_combo'), overrides efficacy with drug-specific cure probability.
+        efficacy: Probability of cure given adherence (0-1). Default 0.85.
+        dur_treatment: Treatment duration distribution. Default 180 days.
+        adherence: Probability of completing the full course (0-1). Default 0.85.
+        drug_type: If provided (e.g. 'dots', 'first_line_combo'), overrides
+            efficacy, dur_treatment, and adherence with drug-specific values.
     """
 
-    def __init__(self, efficacy=0.85, drug_type=None, **kwargs):
+    def __init__(self, efficacy=0.85, dur_treatment=None, adherence=0.85, drug_type=None, **kwargs):
         super().__init__()
         if drug_type is not None:
-            self.efficacy = drug_params[drug_type]['cure_prob']
+            dp = drug_params[drug_type]
+            efficacy = dp['cure_prob']
+            dur_treatment = dur_treatment or ss.constant(v=dp['duration'])
+            adherence = dp['adherence_rate']
         else:
-            self.efficacy = efficacy
+            dur_treatment = dur_treatment or ss.constant(v=180)
 
         self.define_pars(
-            p_success = ss.bernoulli(self.efficacy)
+            p_adherence = ss.bernoulli(adherence),
+            p_success = ss.bernoulli(efficacy),
+            dur_treatment = dur_treatment,
         )
         self.update_pars(**kwargs)
         return
 
     def administer(self, sim, uids):
         """
-        Administer treatment to agents.
+        Roll treatment outcomes for agents starting treatment.
+
+        First rolls adherence (will they complete the course?), then rolls
+        cure probability for adherent agents. Non-adherent agents are failures.
 
         Returns:
             dict with 'success' and 'failure' UIDs.
         """
-        success_uids, failure_uids = self.pars.p_success.filter(uids, both=True)
+        adherent, non_adherent = self.pars.p_adherence.filter(uids, both=True)
+        success_uids, adherent_fail = self.pars.p_success.filter(adherent, both=True)
+        failure_uids = ss.uids.cat([non_adherent, adherent_fail])
         return {'success': success_uids, 'failure': failure_uids}
 
 
@@ -120,6 +133,10 @@ class TxDelivery(ss.Intervention):
             ss.IntArr('n_times_treated', default=0),
             ss.BoolState('tb_treatment_success', default=False),
             ss.BoolArr('treatment_failure', default=False),
+            ss.FloatArr('ti_treatment_start'),
+            ss.FloatArr('ti_treatment_end'),
+            ss.BoolArr('pending_success', default=False),
+            ss.BoolArr('pending_failure', default=False),
         )
         self.update_pars(**kwargs)
         product.name = f'{self.name}_product'
@@ -155,93 +172,123 @@ class TxDelivery(ss.Intervention):
 
     def step(self):
         """ Coordinate everything that happens on the step; details are in methods below """
-        self.step_eligibility() # Check eligibility
-        self.step_start_treatment() # Start treatment for eligible agents
-        self.step_administer() # Administer product and handle outcomes
-        self.step_success() # Handle success
-        self.step_failures() # Handle failures
+        self.step_eligibility()        # Check eligibility
+        self.step_start_treatment()    # Start treatment for newly eligible agents
+        self.step_check_completion()   # Check if any on-treatment agents have completed
+        self.step_success()            # Handle completed successes
+        self.step_failures()           # Handle completed failures
         return
-    
+
     def step_eligibility(self):
         """ Check agents for eligibility, and start treatment for those eligible """
         self._elig_uids = self._get_eligible(self.sim)
         return self._elig_uids
 
     def step_start_treatment(self):
-        """ Start treatment for eligible agents """
+        """
+        Start treatment for eligible agents.
+
+        Latent/acute agents are cleared immediately. Active TB agents are put
+        into TREATMENT state and their outcome (success/failure) is pre-rolled
+        via the product, but not resolved until dur_treatment has elapsed.
+        """
         tb = self.sim.get_tb()
         uids = self._elig_uids
 
-        # ACUTE or INFECTION: clear (NB, acute may not be present in all models, but fine to check)
+        # ACUTE or INFECTION: clear immediately (no treatment course needed)
         latent = uids[np.isin(tb.state[uids], [TBS.ACUTE, TBS.INFECTION])]
         tb.state[latent] = TBS.CLEARED
         tb.rr_reinfection[latent] = tb.pars.rr_reinfection_cleared
         if tb.pars.dur_reinfection_protection is not None and len(latent):
-            self.ti_rr_reinfection_wane[latent] = self.ti + tb.pars.dur_reinfection_protection.rvs(latent)
+            tb.ti_rr_reinfection_wane[latent] = self.ti + tb.pars.dur_reinfection_protection.rvs(latent)
         tb.infected[latent] = False
         tb.susceptible[latent] = True
 
         # Active TB: put on treatment
         active = uids[np.isin(tb.state[uids], [TBS.NON_INFECTIOUS, TBS.ASYMPTOMATIC, TBS.SYMPTOMATIC])]
+        if len(active) == 0:
+            self._newly_treated = ss.uids()
+            return
+
         tb.state[active] = TBS.TREATMENT
         tb.on_treatment[active] = True
-        tb.results['new_notifications_15+'][tb.ti] += np.count_nonzero(self.sim.people.age[active] >= 15) # TODO: should this result be in the intervention instead?
+        tb.results['new_notifications_15+'][tb.ti] += np.count_nonzero(self.sim.people.age[active] >= 15)
 
-        # Only proceed with agents actually on treatment
-        tx_uids = uids[tb.on_treatment[uids]]
-        self.n_times_treated[tx_uids] += 1
-        self._tx_uids = tx_uids
+        # Record treatment timing
+        dur = self.product.pars.dur_treatment.rvs(active)
+        self.ti_treatment_start[active] = self.ti
+        self.ti_treatment_end[active] = self.ti + dur
+        self.n_times_treated[active] += 1
+
+        # Pre-roll outcomes (stored as pending, resolved when treatment completes)
+        outcomes = self.product.administer(self.sim, active)
+        self.pending_success[outcomes.get('success', ss.uids())] = True
+        self.pending_failure[outcomes.get('failure', ss.uids())] = True
+
+        self._newly_treated = active
         return
-    
-    def step_administer(self):
-        """ Administer product to get success/failure """
-        outcomes = self.product.administer(self.sim, self._tx_uids)
-        self._outcomes = outcomes
-        self._success = outcomes.get('success', ss.uids())
-        self._fail = outcomes.get('failure', ss.uids())
+
+    def step_check_completion(self):
+        """ Find agents whose treatment course has completed this step """
+        tb = self.sim.get_tb()
+        on_tx = tb.on_treatment.uids
+        if len(on_tx) == 0:
+            self._success = ss.uids()
+            self._fail = ss.uids()
+            return
+
+        completed = on_tx[self.ti >= self.ti_treatment_end[on_tx]]
+        self._success = completed[self.pending_success[completed]]
+        self._fail = completed[self.pending_failure[completed]]
         return
-    
+
     def step_success(self):
-        """Successful treatment clears infection and sets reinfection protection"""
+        """ Successful treatment clears infection and sets reinfection protection """
         tb = self.sim.get_tb()
         success_uids = self._success
-        if len(success_uids) > 0:
-            tb.state[success_uids] = TBS.CLEARED
-            tb.on_treatment[success_uids] = False
-            tb.susceptible[success_uids] = True
-            tb.infected[success_uids] = False
-            if self._dx is not None:
-                self._dx.diagnosed[success_uids] = False
-            self.tb_treatment_success[success_uids] = True
+        if len(success_uids) == 0:
+            return
 
-            # Reinfection protection (moved from TB natural history)
-            tb.rr_reinfection[success_uids] = tb.pars.rr_reinfection_treat
-            if tb.pars.dur_reinfection_protection is not None and len(success_uids):
-                tb.ti_rr_reinfection_wane[success_uids] = tb.ti + tb.pars.dur_reinfection_protection.rvs(success_uids)
+        tb.state[success_uids] = TBS.CLEARED
+        tb.on_treatment[success_uids] = False
+        tb.susceptible[success_uids] = True
+        tb.infected[success_uids] = False
+        if self._dx is not None:
+            self._dx.diagnosed[success_uids] = False
+        self.tb_treatment_success[success_uids] = True
+        self.pending_success[success_uids] = False
+
+        # Reinfection protection
+        tb.rr_reinfection[success_uids] = tb.pars.rr_reinfection_treat
+        if tb.pars.dur_reinfection_protection is not None and len(success_uids):
+            tb.ti_rr_reinfection_wane[success_uids] = tb.ti + tb.pars.dur_reinfection_protection.rvs(success_uids)
         return
 
     def step_failures(self):
-        """Handle failures: return to symptomatic and trigger re-care-seeking"""
+        """ Handle failures: return to symptomatic and trigger re-care-seeking """
         tb = self.sim.get_tb()
         failure_uids = self._fail
-        if len(failure_uids) > 0:
-            tb.state[failure_uids] = TBS.SYMPTOMATIC
-            tb.on_treatment[failure_uids] = False
-            self.treatment_failure[failure_uids] = True
+        if len(failure_uids) == 0:
+            return
 
-            if self.reset_flags and self._dx is not None:
-                self._dx.diagnosed[failure_uids] = False
-                self._dx.tested[failure_uids] = False
+        tb.state[failure_uids] = TBS.SYMPTOMATIC
+        tb.on_treatment[failure_uids] = False
+        self.treatment_failure[failure_uids] = True
+        self.pending_failure[failure_uids] = False
 
-            # Trigger renewed care-seeking
-            if hsb := self.sim.get_hsb():
-                hsb.sought_care[failure_uids] = False
-            if self._dx is not None:
-                self._dx.care_seeking_multiplier[failure_uids] *= self.reseek_multiplier
+        if self.reset_flags and self._dx is not None:
+            self._dx.diagnosed[failure_uids] = False
+            self._dx.tested[failure_uids] = False
+
+        # Trigger renewed care-seeking
+        if hsb := self.sim.get_hsb():
+            hsb.sought_care[failure_uids] = False
+        if self._dx is not None:
+            self._dx.care_seeking_multiplier[failure_uids] *= self.reseek_multiplier
         return
 
     def update_results(self):
-        self.results.n_treated[self.ti] = len(self._tx_uids)
+        self.results.n_treated[self.ti] = len(self._newly_treated)
         self.results.n_success[self.ti] = len(self._success)
         self.results.n_failure[self.ti] = len(self._fail)
         return
@@ -254,10 +301,9 @@ class TxDelivery(ss.Intervention):
     
     def shrink(self):
         """ Remove temporary results """
-        self._outcomes = None
         self._elig_uids = None
-        self._tx_uids = None
+        self._newly_treated = None
         self._success = None
         self._fail = None
-        self._dx = None # Link to treatment module
+        self._dx = None
         return

--- a/tbsim/interventions/treatments.py
+++ b/tbsim/interventions/treatments.py
@@ -38,10 +38,12 @@ class Tx(ss.Product):
         if drug_type is not None:
             dp = drug_params[drug_type]
             efficacy = dp['cure_prob']
-            dur_treatment = dur_treatment or ss.constant(v=dp['duration'].days)
+            if dur_treatment is None:
+                dur_treatment = ss.constant(v=dp['duration'].days)
             adherence = dp['adherence_rate']
         else:
-            dur_treatment = dur_treatment or ss.constant(v=ss.days(180).days)
+            if dur_treatment is None:
+                dur_treatment = ss.constant(v=ss.days(180).days)
 
         self.define_pars(
             p_adherence = ss.bernoulli(adherence),

--- a/tbsim/interventions/treatments.py
+++ b/tbsim/interventions/treatments.py
@@ -139,6 +139,7 @@ class TxDelivery(ss.Intervention):
             ss.FloatArr('ti_treatment_end'),
             ss.BoolArr('pending_success', default=False),
             ss.BoolArr('pending_failure', default=False),
+            ss.IntArr('prior_state', default=int(TBS.SUSCEPTIBLE)),
         )
         self.update_pars(**kwargs)
         product.name = f'{self.name}_product'
@@ -212,6 +213,7 @@ class TxDelivery(ss.Intervention):
             self._newly_treated = ss.uids()
             return
 
+        self.prior_state[active] = tb.state[active]
         tb.state[active] = TBS.TREATMENT
         tb.on_treatment[active] = True
         tb.results['new_notifications_15+'][tb.ti] += np.count_nonzero(self.sim.people.age[active] >= 15)
@@ -268,13 +270,13 @@ class TxDelivery(ss.Intervention):
         return
 
     def step_failures(self):
-        """ Handle failures: return to symptomatic and trigger re-care-seeking """
+        """ Handle failures: return to prior TB state and trigger re-care-seeking """
         tb = self.sim.get_tb()
         failure_uids = self._fail
         if len(failure_uids) == 0:
             return
 
-        tb.state[failure_uids] = TBS.SYMPTOMATIC
+        tb.state[failure_uids] = self.prior_state[failure_uids]
         tb.on_treatment[failure_uids] = False
         self.treatment_failure[failure_uids] = True
         self.pending_failure[failure_uids] = False

--- a/tbsim/tb.py
+++ b/tbsim/tb.py
@@ -147,7 +147,7 @@ class TB(BaseTB):
             trans_asymp=0.82,                   # κ kappa: rel. transmissibility asymptomatic vs symptomatic
             rr_reinfection_rec=0.21,            # π pi: RR reinfection after NON_INFECTIOUS → CLEARED
             rr_reinfection_treat=3.15,          # ρ rho: RR reinfection after TREATMENT → CLEARED
-            rr_reinfection_cleared=1.0,         # RR reinfection after INFECTION → CLEARED (latent cleared)
+            rr_reinfection_cleared=1.0,         # RR reinfection after INFECTION → CLEARED (latent cleared); also applies to agents cleared via TPT sterilization
             dur_reinfection_protection=None,    # Distribution of protection duration; None = never wanes
             # --- From INFECTION (latent) ---
             inf_cle=ss.peryear(1.90),            # Clear infection (no active TB)

--- a/tbsim_examples/run_tb_interventions.py
+++ b/tbsim_examples/run_tb_interventions.py
@@ -198,73 +198,6 @@ def run_dx_tx_cascade():
     return sim
 
 
-def run_tpt_household():
-    """
-    Demonstrate household contact tracing TPT.
-
-    When an index case starts TB treatment, their household contacts
-    are traced and offered TPT (preventive therapy).
-    """
-    # Create synthetic DHS household data
-    n_households = 200
-    hh_ids = np.arange(n_households)
-    age_strings = []
-    for _ in range(n_households):
-        hh_size = np.random.randint(2, 6)
-        ages = np.random.randint(1, 70, hh_size)
-        age_strings.append(sc.strjoin(ages))
-    dhs_data = sc.dataframe(hh_id=hh_ids, ages=age_strings)
-
-    # Household network + random community network
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
-    community_net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=3), dur=0))
-
-    # Dx/Tx cascade to get index cases onto treatment
-    hsb = tbsim.HealthSeekingBehavior()
-    screen = tbsim.DxDelivery(
-        name='screen',
-        product=tbsim.CAD(),
-        coverage=0.9,
-        result_state='screen_positive',
-    )
-    confirm = tbsim.DxDelivery(
-        name='confirm',
-        product=tbsim.Xpert(),
-        coverage=0.8,
-        eligibility=lambda sim: (
-            sim.people.screen.screen_positive
-            & ~sim.people.confirm.tested
-            & sim.people.alive
-        ).uids,
-        result_state='diagnosed',
-    )
-    treat = tbsim.TxDelivery(product=tbsim.DOTS())
-
-    # TPT household contact tracing: 80% follow-up coverage
-    tpt_hh = tbsim.TPTHousehold(pars={'coverage': 0.8})
-
-    sim = tbsim.Sim(
-        n_agents=5000,
-        start='2000',
-        stop='2020',
-        rand_seed=42,
-        init_prev=ss.bernoulli(p=0.30),
-        beta=ss.peryear(0.05),
-        networks=[hh_net, community_net],
-        interventions=[hsb, screen, confirm, treat, tpt_hh],
-    )
-    sim.run()
-
-    # Print summary
-    r = sim.results
-    tpt_r = r.tpthousehold
-    tx_r = r.txdelivery
-    print(f"\nTPT Household Contact Tracing Results:")
-    print(f"  Index cases treated: {tx_r.n_treated.values.sum()}")
-    print(f"  Contacts initiated:  {tpt_r.n_newly_initiated.values.sum()}")
-    print(f"  Currently protected (final): {tpt_r.n_protected.values[-1]}")
-    return sim
-
 
 def run_tpt_cascade():
     """
@@ -375,9 +308,6 @@ if __name__ == '__main__':
     print("\n--- Dx/Tx Cascade Example ---")
     sim = run_dx_tx_cascade()
 
-    # Run TPT household contact tracing example
-    print("\n--- TPT Household Contact Tracing Example ---")
-    sim_tpt = run_tpt_household()
 
     # Run full TPT cascade example
     print("\n--- Full TPT Cascade Example ---")

--- a/tbsim_examples/run_tb_interventions.py
+++ b/tbsim_examples/run_tb_interventions.py
@@ -266,6 +266,107 @@ def run_tpt_household():
     return sim
 
 
+def run_tpt_cascade():
+    """
+    Full TPT cascade: HSB → Dx → household contact tracing → triage.
+
+    Index case pathway:
+        HSB → CXR screen → Xpert confirm → DOTS treatment
+
+    Contact tracing pathway:
+        HouseholdContactTracing detects new treatment starts →
+        DxDelivery screens contacts →
+        Active TB contacts → TxDelivery (via diagnosed flag) →
+        Non-active contacts → TPTDelivery (preventive therapy)
+    """
+    # Create synthetic DHS household data
+    n_households = 200
+    hh_ids = np.arange(n_households)
+    age_strings = []
+    for _ in range(n_households):
+        hh_size = np.random.randint(2, 6)
+        ages = np.random.randint(1, 70, hh_size)
+        age_strings.append(sc.strjoin(ages))
+    dhs_data = sc.dataframe(hh_id=hh_ids, ages=age_strings)
+
+    # Networks
+    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    community_net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=3), dur=0))
+
+    # --- Index case pathway ---
+    hsb = tbsim.HealthSeekingBehavior()
+    screen = tbsim.DxDelivery(
+        name='screen',
+        product=tbsim.CAD(),
+        coverage=0.9,
+        result_state='screen_positive',
+        result_validity=ss.days(180),
+    )
+    confirm = tbsim.DxDelivery(
+        name='confirm',
+        product=tbsim.Xpert(),
+        coverage=0.8,
+        eligibility=lambda sim: (
+            sim.people.screen.screen_positive
+            & ~sim.people.confirm.tested
+            & sim.people.alive
+        ).uids,
+        result_state='diagnosed',
+    )
+    treat = tbsim.TxDelivery(product=tbsim.DOTS())
+
+    # --- Contact tracing pathway ---
+    hh_tracing = tbsim.HouseholdContactTracing(coverage=0.8)
+
+    # Screen contacts for active TB
+    contact_screen = tbsim.DxDelivery(
+        name='contact_screen',
+        product=tbsim.Xpert(),
+        coverage=1.0,
+        eligibility=lambda sim: (
+            sim.people.householdcontacttracing.contact_identified
+            & ~sim.people.contact_screen.tested
+            & sim.people.alive
+        ).uids,
+        result_state='diagnosed',  # positive contacts → TxDelivery picks them up
+    )
+
+    # TPT for contacts screened negative (no active disease)
+    tpt = tbsim.TPTDelivery(
+        product=tbsim.TPTTx(),
+        contact_tracing='householdcontacttracing',
+        contact_screen='contact_screen',
+    )
+
+    sim = tbsim.Sim(
+        n_agents=5000,
+        start='2000',
+        stop='2020',
+        rand_seed=42,
+        init_prev=ss.bernoulli(p=0.30),
+        beta=ss.peryear(0.05),
+        networks=[hh_net, community_net],
+        interventions=[hsb, screen, confirm, treat, hh_tracing, contact_screen, tpt],
+    )
+    sim.run()
+
+    # Print summary
+    r = sim.results
+    ct_r = r.householdcontacttracing
+    cs_r = r.contact_screen
+    tx_r = r.txdelivery
+    tpt_r = r.tptdelivery
+    print(f"\nTPT Cascade Results:")
+    print(f"  Index cases followed up:  {ct_r.n_index_followed_up.values.sum()}")
+    print(f"  Contacts identified:      {ct_r.n_contacts_identified.values.sum()}")
+    print(f"  Contacts screened:        {cs_r.n_tested.values.sum()}")
+    print(f"  Contacts diagnosed (active TB): {cs_r.n_positive.values.sum()}")
+    print(f"  Total treated:            {tx_r.n_treated.values.sum()}")
+    print(f"  TPT initiated:            {tpt_r.n_tpt_initiated.values.sum()}")
+    print(f"  TPT protected (final):    {tpt_r.n_protected.values[-1]}")
+    return sim
+
+
 if __name__ == '__main__':
     # Run all scenarios
     # results = run_scenarios(plot=True)
@@ -277,3 +378,7 @@ if __name__ == '__main__':
     # Run TPT household contact tracing example
     print("\n--- TPT Household Contact Tracing Example ---")
     sim_tpt = run_tpt_household()
+
+    # Run full TPT cascade example
+    print("\n--- Full TPT Cascade Example ---")
+    sim_cascade = run_tpt_cascade()

--- a/tbsim_examples/run_tb_interventions.py
+++ b/tbsim_examples/run_tb_interventions.py
@@ -161,6 +161,7 @@ def run_dx_tx_cascade():
         product=tbsim.CAD(),
         coverage=0.9,
         result_state='screen_positive',
+        result_validity=ss.days(180),  # Screen result valid for 6 months
     )
     confirm = tbsim.DxDelivery(
         name='confirm',
@@ -171,6 +172,7 @@ def run_dx_tx_cascade():
             & ~sim.people.confirm.tested
         ).uids,
         result_state='diagnosed',
+        result_validity=ss.days(365),  # Diagnosis valid for 1 year
     )
     treat = tbsim.TxDelivery(product=tbsim.DOTS())
 

--- a/tbsim_examples/run_tb_interventions.py
+++ b/tbsim_examples/run_tb_interventions.py
@@ -2,6 +2,7 @@
 TB interventions example: scenarios with BCG, TPT, BetaByYear, and Dx/Tx cascade.
 """
 
+import numpy as np
 import sciris as sc
 import starsim as ss
 import tbsim
@@ -174,12 +175,12 @@ def run_dx_tx_cascade():
     treat = tbsim.TxDelivery(product=tbsim.DOTS())
 
     sim = tbsim.Sim(
-        n_agents=1000,
+        n_agents=5000,
         start='2000',
         stop='2020',
         rand_seed=42,
-        init_prev=ss.bernoulli(p=0.25),
-        beta=ss.peryear(0.0025),
+        init_prev=ss.bernoulli(p=0.30),
+        beta=ss.peryear(0.05),
         interventions=[hsb, screen, confirm, treat],
     )
     sim.run()
@@ -195,10 +196,82 @@ def run_dx_tx_cascade():
     return sim
 
 
+def run_tpt_household():
+    """
+    Demonstrate household contact tracing TPT.
+
+    When an index case starts TB treatment, their household contacts
+    are traced and offered TPT (preventive therapy).
+    """
+    # Create synthetic DHS household data
+    n_households = 200
+    hh_ids = np.arange(n_households)
+    age_strings = []
+    for _ in range(n_households):
+        hh_size = np.random.randint(2, 6)
+        ages = np.random.randint(1, 70, hh_size)
+        age_strings.append(sc.strjoin(ages))
+    dhs_data = sc.dataframe(hh_id=hh_ids, ages=age_strings)
+
+    # Household network + random community network
+    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    community_net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=3), dur=0))
+
+    # Dx/Tx cascade to get index cases onto treatment
+    hsb = tbsim.HealthSeekingBehavior()
+    screen = tbsim.DxDelivery(
+        name='screen',
+        product=tbsim.CAD(),
+        coverage=0.9,
+        result_state='screen_positive',
+    )
+    confirm = tbsim.DxDelivery(
+        name='confirm',
+        product=tbsim.Xpert(),
+        coverage=0.8,
+        eligibility=lambda sim: (
+            sim.people.screen.screen_positive
+            & ~sim.people.confirm.tested
+            & sim.people.alive
+        ).uids,
+        result_state='diagnosed',
+    )
+    treat = tbsim.TxDelivery(product=tbsim.DOTS())
+
+    # TPT household contact tracing: 80% follow-up coverage
+    tpt_hh = tbsim.TPTHousehold(pars={'coverage': 0.8})
+
+    sim = tbsim.Sim(
+        n_agents=5000,
+        start='2000',
+        stop='2020',
+        rand_seed=42,
+        init_prev=ss.bernoulli(p=0.30),
+        beta=ss.peryear(0.05),
+        networks=[hh_net, community_net],
+        interventions=[hsb, screen, confirm, treat, tpt_hh],
+    )
+    sim.run()
+
+    # Print summary
+    r = sim.results
+    tpt_r = r.tpthousehold
+    tx_r = r.txdelivery
+    print(f"\nTPT Household Contact Tracing Results:")
+    print(f"  Index cases treated: {tx_r.n_treated.values.sum()}")
+    print(f"  Contacts initiated:  {tpt_r.n_newly_initiated.values.sum()}")
+    print(f"  Currently protected (final): {tpt_r.n_protected.values[-1]}")
+    return sim
+
+
 if __name__ == '__main__':
     # Run all scenarios
-    results = run_scenarios(plot=True)
+    # results = run_scenarios(plot=True)
 
     # Run Dx/Tx cascade example
     print("\n--- Dx/Tx Cascade Example ---")
     sim = run_dx_tx_cascade()
+
+    # Run TPT household contact tracing example
+    print("\n--- TPT Household Contact Tracing Example ---")
+    sim_tpt = run_tpt_household()

--- a/tests/test_bcg.py
+++ b/tests/test_bcg.py
@@ -39,8 +39,8 @@ def test_bcg_default_values():
 
     # Delivery pars on the intervention
     assert '0.5' in str(bcg.pars.coverage) or '0.50' in str(bcg.pars.coverage)
-    assert bcg.pars.start == ss.date('1900-01-01')
-    assert bcg.pars.stop == ss.date('2100-12-31')
+    assert bcg.pars.start == sim.pars.start
+    assert bcg.pars.stop == sim.pars.stop
     assert bcg.pars.age_range == [0, 5]
 
     # Biological pars on the product

--- a/tests/test_dx_delivery.py
+++ b/tests/test_dx_delivery.py
@@ -72,6 +72,48 @@ def test_dx_delivery_cascade():
     assert sim.results.confirm.n_tested.sum() > 0
 
 
+def test_result_expiry_resets_state():
+    """With short result_validity, fewer agents are diagnosed at end of sim vs no expiry."""
+    dx_expiry = tbsim.DxDelivery(product=tbsim.Xpert(), result_state='diagnosed', result_validity=ss.days(30))
+    sim_expiry = make_sim(n_agents=500, interventions=dx_expiry)
+    sim_expiry.run()
+    n_diagnosed_expiry = sim_expiry.people.dxdelivery.diagnosed.count()
+
+    dx_persist = tbsim.DxDelivery(product=tbsim.Xpert(), result_state='diagnosed', result_validity=None)
+    sim_persist = make_sim(n_agents=500, interventions=dx_persist)
+    sim_persist.run()
+    n_diagnosed_persist = sim_persist.people.dxdelivery.diagnosed.count()
+
+    # With expiry, fewer agents should be diagnosed at end (most expired)
+    assert n_diagnosed_expiry < n_diagnosed_persist, \
+        f"Expected fewer diagnosed with expiry ({n_diagnosed_expiry}) vs persist ({n_diagnosed_persist})"
+
+
+def test_result_expiry_none_persists():
+    """result_validity=None preserves result state indefinitely (default behavior)."""
+    dx = tbsim.DxDelivery(product=tbsim.Xpert(), result_state='diagnosed', result_validity=None)
+    sim = make_sim(n_agents=500, interventions=dx)
+    sim.run()
+
+    # Some agents should still be diagnosed at the end
+    assert sim.people.dxdelivery.diagnosed.count() > 0
+
+
+def test_result_expiry_re_eligible():
+    """Agents with expired results become eligible for re-testing."""
+    dx = tbsim.DxDelivery(
+        product=tbsim.Xpert(),
+        result_state='diagnosed',
+        result_validity=ss.days(30),
+    )
+    sim = make_sim(n_agents=500, interventions=dx)
+    sim.run()
+
+    # Over a long sim with short validity, agents should be tested multiple times
+    max_times = sim.people.dxdelivery.n_times_tested.values.max()
+    assert max_times > 1, "With short validity, agents should be re-tested after expiry"
+
+
 def test_dx_delivery_coverage():
     """DxDelivery with coverage < 1.0 tests fewer agents."""
     dx_full = tbsim.DxDelivery(product=tbsim.Xpert(), coverage=1.0)

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -517,10 +517,10 @@ def test_tpt_sterilization_clears_infection():
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
-    product = tbsim.TPTTx(
-        p_sterilization=1.0, p_suppression=0.0,
-        pars={'dur_treatment': ss.constant(v=ss.days(0))},  # Instant treatment
-    )
+    product = tbsim.TPTTx(pars={
+        'p_sterilization': 1.0, 'p_suppression': 0.0,
+        'dur_treatment': ss.constant(v=ss.days(0)),  # Instant treatment
+    })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
     sim.init()
@@ -555,13 +555,11 @@ def test_tpt_suppression_applies_modifiers():
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
-    product = tbsim.TPTTx(
-        p_sterilization=0.0, p_suppression=1.0,
-        pars={
-            'dur_treatment': ss.constant(v=ss.days(0)),
-            'dur_protection': ss.constant(v=ss.years(10)),
-        },
-    )
+    product = tbsim.TPTTx(pars={
+        'p_sterilization': 0.0, 'p_suppression': 1.0,
+        'dur_treatment': ss.constant(v=ss.days(0)),
+        'dur_protection': ss.constant(v=ss.years(10)),
+    })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
     sim.init()
@@ -588,10 +586,10 @@ def test_tpt_neither_gets_no_benefit():
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
-    product = tbsim.TPTTx(
-        p_sterilization=0.0, p_suppression=0.0,
-        pars={'dur_treatment': ss.constant(v=ss.days(7))},
-    )
+    product = tbsim.TPTTx(pars={
+        'p_sterilization': 0.0, 'p_suppression': 0.0,
+        'dur_treatment': ss.constant(v=ss.days(7)),
+    })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
     sim.init()
@@ -611,10 +609,10 @@ def test_tpt_mechanisms_mutually_exclusive():
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
-    product = tbsim.TPTTx(
-        p_sterilization=0.5, p_suppression=0.5,
-        pars={'dur_treatment': ss.constant(v=ss.days(7))},
-    )
+    product = tbsim.TPTTx(pars={
+        'p_sterilization': 0.5, 'p_suppression': 0.5,
+        'dur_treatment': ss.constant(v=ss.days(7)),
+    })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
     sim.init()
@@ -664,7 +662,7 @@ def test_tpt_backward_compatible_defaults():
 def test_tpt_invalid_probabilities():
     """Raise error if p_sterilization + p_suppression > 1."""
     with pytest.raises(ValueError, match="must be <= 1.0"):
-        tbsim.TPTTx(p_sterilization=0.6, p_suppression=0.6)
+        tbsim.TPTTx(pars={'p_sterilization': 0.6, 'p_suppression': 0.6})
 
 
 def test_tpt_mechanism_via_pars_dict():
@@ -672,7 +670,3 @@ def test_tpt_mechanism_via_pars_dict():
     product = tbsim.TPTTx(pars={'p_sterilization': 0.7, 'p_suppression': 0.3})
     assert np.isclose(product.pars.p_sterilization, 0.7)
     assert np.isclose(product.pars.p_suppression, 0.3)
-
-    # Also works via constructor args (existing path)
-    product2 = tbsim.TPTTx(p_sterilization=0.7, p_suppression=0.3)
-    assert np.isclose(product2.pars.p_sterilization, 0.7)

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -518,7 +518,7 @@ def test_tpt_sterilization_clears_infection():
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
     product = tbsim.TPTTx(pars={
-        'p_sterilization': 1.0, 'p_suppression': 0.0,
+        'efficacy': ss.bernoulli(p=1.0), 'p_sterilize': ss.bernoulli(p=1.0),
         'dur_treatment': ss.constant(v=ss.days(0)),  # Instant treatment
     })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
@@ -546,7 +546,7 @@ def test_tpt_sterilization_clears_infection():
 
     # None should be protected (suppression)
     assert tpt.product.tpt_protected.count() == 0, \
-        "No agents should be in suppression protection with p_suppression=0"
+        "No agents should be in suppression protection with p_sterilization=1"
 
 
 def test_tpt_suppression_applies_modifiers():
@@ -556,7 +556,7 @@ def test_tpt_suppression_applies_modifiers():
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
     product = tbsim.TPTTx(pars={
-        'p_sterilization': 0.0, 'p_suppression': 1.0,
+        'efficacy': ss.bernoulli(p=1.0),
         'dur_treatment': ss.constant(v=ss.days(0)),
         'dur_protection': ss.constant(v=ss.years(10)),
     })
@@ -587,7 +587,7 @@ def test_tpt_neither_gets_no_benefit():
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
     product = tbsim.TPTTx(pars={
-        'p_sterilization': 0.0, 'p_suppression': 0.0,
+        'efficacy': ss.bernoulli(p=0.0),
         'dur_treatment': ss.constant(v=ss.days(7)),
     })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
@@ -610,7 +610,7 @@ def test_tpt_mechanisms_mutually_exclusive():
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
     product = tbsim.TPTTx(pars={
-        'p_sterilization': 0.5, 'p_suppression': 0.5,
+        'efficacy': ss.bernoulli(p=1.0), 'p_sterilize': ss.bernoulli(p=0.5),
         'dur_treatment': ss.constant(v=ss.days(7)),
     })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
@@ -631,9 +631,9 @@ def test_tpt_mechanisms_mutually_exclusive():
     assert len(both) == 0, "No agent should have both sterilization and suppression"
 
 
-def test_tpt_backward_compatible_defaults():
-    """Default params (p_sterilization=0, p_suppression=1) produce suppression-only behavior."""
-    nagents = 100
+def test_tpt_default_efficacy():
+    """Default params (efficacy=0.6, p_sterilize=0) produce suppression or nothing."""
+    nagents = 200
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
@@ -649,24 +649,24 @@ def test_tpt_backward_compatible_defaults():
     tpt.step()
     tpt.step()
 
-    # All initiated agents should have suppression mechanism
+    # With default p_sterilize=0, mechanisms should be SUPPRESS or NONE only
     initiated = tpt.initiated.uids
     if len(initiated) > 0:
         mechs = np.asarray(tpt.product.tpt_mechanism[initiated])
-        assert np.all(mechs == tbsim.TPTTx.MECH_SUPPRESS), \
-            "Default should assign all agents to suppression"
-    # No sterilized agents
-    assert tpt.product.tpt_resolved.count() == 0
-
-
-def test_tpt_invalid_probabilities():
-    """Raise error if p_sterilization + p_suppression > 1."""
-    with pytest.raises(ValueError, match="must be <= 1.0"):
-        tbsim.TPTTx(pars={'p_sterilization': 0.6, 'p_suppression': 0.6})
+        assert np.all(np.isin(mechs, [tbsim.TPTTx.MECH_NONE, tbsim.TPTTx.MECH_SUPPRESS])), \
+            "Default should assign agents to suppression or nothing (no sterilization)"
+        # Some should be protected (suppression) and some resolved (no benefit)
+        n_suppress = np.count_nonzero(mechs == tbsim.TPTTx.MECH_SUPPRESS)
+        n_none     = np.count_nonzero(mechs == tbsim.TPTTx.MECH_NONE)
+        assert n_suppress > 0, "Some agents should get suppression"
+        assert n_none > 0, "Some agents should get no benefit (efficacy < 1)"
 
 
 def test_tpt_mechanism_via_pars_dict():
     """Mechanism probabilities can be passed via pars dict."""
-    product = tbsim.TPTTx(pars={'p_sterilization': 0.7, 'p_suppression': 0.3})
-    assert np.isclose(product.pars.p_sterilization, 0.7)
-    assert np.isclose(product.pars.p_suppression, 0.3)
+    product = tbsim.TPTTx(pars={
+        'efficacy': ss.bernoulli(p=0.8),
+        'p_sterilize': ss.bernoulli(p=0.3),
+    })
+    assert np.isclose(product.pars.efficacy.pars.p, 0.8)
+    assert np.isclose(product.pars.p_sterilize.pars.p, 0.3)

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -505,3 +505,158 @@ def test_tpt_cascade_triage():
     if n_contact_screened > 0:
         assert (n_tpt + n_contact_positive) > 0, \
             f"Screened {n_contact_screened} contacts but none got TPT or treatment"
+
+
+# ---------------------------------------------------------------------------
+# Sterilization / suppression mechanism tests
+# ---------------------------------------------------------------------------
+
+def test_tpt_sterilization_clears_infection():
+    """Agents with sterilization mechanism move from INFECTION → CLEARED after treatment."""
+    nagents = 200
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(
+        p_sterilization=1.0, p_suppression=0.0,
+        pars={'dur_treatment': ss.constant(v=ss.days(7))},
+    )
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tpt = sim.interventions['tptsimple']
+    tb_disease = sim.diseases.tb
+
+    # Run a few steps to initiate TPT and complete treatment
+    for _ in range(5):
+        tpt.step()
+
+    # Agents who were in INFECTION and got sterilized should now be CLEARED
+    sterilized = tpt.product.tpt_sterilized.uids
+    if len(sterilized) > 0:
+        states = np.asarray(tb_disease.state[sterilized])
+        # Sterilized agents should be CLEARED (or may have been reinfected/progressed)
+        n_cleared = np.count_nonzero(states == tbsim.TBS.CLEARED)
+        assert n_cleared > 0, "Some sterilized agents should be in CLEARED state"
+        # None should be protected (suppression)
+        assert tpt.product.tpt_protected.count() == 0, \
+            "No agents should be in suppression protection with p_suppression=0"
+
+
+def test_tpt_suppression_applies_modifiers():
+    """Agents with suppression mechanism get rr_* modifiers (existing behavior)."""
+    nagents = 200
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(
+        p_sterilization=0.0, p_suppression=1.0,
+        pars={
+            'dur_treatment': ss.constant(v=ss.days(0)),
+            'dur_protection': ss.constant(v=ss.years(10)),
+        },
+    )
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tb_disease = sim.diseases.tb
+    initial_activation = np.array(tb_disease.rr_activation).copy()
+
+    tpt = sim.interventions['tptsimple']
+    tpt.step()
+    tpt.step()
+
+    current_activation = np.array(tb_disease.rr_activation)
+    protected = tpt.product.tpt_protected.uids
+    if len(protected) > 0:
+        assert np.any(current_activation[protected] < initial_activation[protected]), \
+            "Suppression should reduce activation risk for protected agents"
+    # No sterilized agents
+    assert tpt.product.tpt_sterilized.count() == 0
+
+
+def test_tpt_neither_gets_no_benefit():
+    """Agents with mechanism=NONE stay in INFECTION with no modifiers."""
+    nagents = 200
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(
+        p_sterilization=0.0, p_suppression=0.0,
+        pars={'dur_treatment': ss.constant(v=ss.days(7))},
+    )
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tpt = sim.interventions['tptsimple']
+    for _ in range(5):
+        tpt.step()
+
+    # No one should be protected or sterilized
+    assert tpt.product.tpt_protected.count() == 0
+    assert tpt.product.tpt_sterilized.count() == 0
+
+
+def test_tpt_mechanisms_mutually_exclusive():
+    """No agent has both sterilization and suppression."""
+    nagents = 200
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(
+        p_sterilization=0.5, p_suppression=0.5,
+        pars={'dur_treatment': ss.constant(v=ss.days(7))},
+    )
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tpt = sim.interventions['tptsimple']
+    for _ in range(5):
+        tpt.step()
+
+    # Check that mechanisms are 0, 1, or 2 only
+    mechs = np.asarray(tpt.product.tpt_mechanism)
+    initiated = mechs[mechs != 0]
+    assert np.all(np.isin(initiated, [1, 2])), "Mechanisms should be 0, 1, or 2"
+
+    # No agent should be both sterilized and protected
+    both = tpt.product.tpt_sterilized.uids.intersect(tpt.product.tpt_protected.uids)
+    assert len(both) == 0, "No agent should have both sterilization and suppression"
+
+
+def test_tpt_backward_compatible_defaults():
+    """Default params (p_sterilization=0, p_suppression=1) produce suppression-only behavior."""
+    nagents = 100
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(pars={
+        'dur_treatment': ss.constant(v=ss.days(0)),
+        'dur_protection': ss.constant(v=ss.years(10)),
+    })
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tpt = sim.interventions['tptsimple']
+    tpt.step()
+    tpt.step()
+
+    # All initiated agents should have suppression mechanism
+    initiated = tpt.initiated.uids
+    if len(initiated) > 0:
+        mechs = np.asarray(tpt.product.tpt_mechanism[initiated])
+        assert np.all(mechs == tbsim.TPTTx.MECH_SUPPRESS), \
+            "Default should assign all agents to suppression"
+    # No sterilized agents
+    assert tpt.product.tpt_sterilized.count() == 0
+
+
+def test_tpt_invalid_probabilities():
+    """Raise error if p_sterilization + p_suppression > 1."""
+    with pytest.raises(ValueError, match="must be <= 1.0"):
+        tbsim.TPTTx(p_sterilization=0.6, p_suppression=0.6)

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -347,3 +347,161 @@ def test_tpt_household_full_sim_run():
     itv = sim.interventions['tpthousehold']
     assert 'n_newly_initiated' in itv.results
     assert 'n_protected' in itv.results
+
+
+# ---------------------------------------------------------------------------
+# HouseholdContactTracing tests
+# ---------------------------------------------------------------------------
+
+def test_hh_contact_tracing_identifies_contacts():
+    """HouseholdContactTracing sets contact_identified on household members."""
+    dhs_data = make_dhs_data(50)
+    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+
+    tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
+    hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
+
+    sim = ss.Sim(
+        diseases=tb, networks=hh_net,
+        interventions=hh_tracing,
+        pars=dict(dt=ss.days(7), start=ss.date('2000-01-01'), stop=ss.date('2010-12-31')),
+    )
+    sim.init()
+
+    ct = sim.interventions['householdcontacttracing']
+    tb_disease = sim.diseases.tb
+
+    # No contacts before treatment starts
+    ct.step()
+    assert ct.contact_identified.count() == 0
+
+    # Force an agent onto treatment
+    tb_disease.on_treatment[ss.uids([0])] = True
+    ct.step()
+
+    # Should have identified contacts
+    n_identified = ct.contact_identified.count()
+    # Agent 0 should NOT be in contacts
+    if n_identified > 0:
+        assert not ct.contact_identified[0], "Index case should not be identified as contact"
+
+
+def test_hh_contact_tracing_no_retrigger():
+    """Same index case does not retrigger contact identification."""
+    dhs_data = make_dhs_data(50)
+    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+
+    tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
+    hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
+
+    sim = ss.Sim(
+        diseases=tb, networks=hh_net,
+        interventions=hh_tracing,
+        pars=dict(dt=ss.days(7), start=ss.date('2000-01-01'), stop=ss.date('2010-12-31')),
+    )
+    sim.init()
+
+    ct = sim.interventions['householdcontacttracing']
+    tb_disease = sim.diseases.tb
+
+    tb_disease.on_treatment[ss.uids([0])] = True
+    ct.step()
+    n1 = ct._n_contacts
+
+    # Second step: same agent still on treatment, no new starts
+    ct.step()
+    assert ct._n_contacts == 0, "Same index should not retrigger"
+
+
+# ---------------------------------------------------------------------------
+# Full TPT cascade tests
+# ---------------------------------------------------------------------------
+
+def _make_cascade_sim(n_agents=500, n_households=100, rand_seed=42):
+    """Build a full TPT cascade sim for testing."""
+    dhs_data = make_dhs_data(n_households)
+    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    community_net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=3), dur=0))
+
+    hsb = tbsim.HealthSeekingBehavior()
+    screen = tbsim.DxDelivery(
+        name='screen', product=tbsim.CAD(), coverage=0.9,
+        result_state='screen_positive',
+    )
+    confirm = tbsim.DxDelivery(
+        name='confirm', product=tbsim.Xpert(), coverage=0.8,
+        eligibility=lambda sim: (
+            sim.people.screen.screen_positive
+            & ~sim.people.confirm.tested
+            & sim.people.alive
+        ).uids,
+        result_state='diagnosed',
+    )
+    treat = tbsim.TxDelivery(product=tbsim.DOTS())
+
+    hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
+    contact_screen = tbsim.DxDelivery(
+        name='contact_screen', product=tbsim.Xpert(), coverage=1.0,
+        eligibility=lambda sim: (
+            sim.people.householdcontacttracing.contact_identified
+            & ~sim.people.contact_screen.tested
+            & sim.people.alive
+        ).uids,
+        result_state='diagnosed',
+    )
+    tpt = tbsim.TPTDelivery(
+        product=tbsim.TPTTx(),
+        contact_tracing='householdcontacttracing',
+        contact_screen='contact_screen',
+    )
+
+    sim = tbsim.Sim(
+        n_agents=n_agents, start='2000', stop='2010', rand_seed=rand_seed,
+        init_prev=ss.bernoulli(p=0.30), beta=ss.peryear(0.05),
+        networks=[hh_net, community_net],
+        interventions=[hsb, screen, confirm, treat, hh_tracing, contact_screen, tpt],
+    )
+    return sim
+
+
+def test_tpt_cascade_runs():
+    """Full TPT cascade completes without error."""
+    sim = _make_cascade_sim()
+    sim.run()
+
+    r = sim.results
+    assert r.householdcontacttracing.n_contacts_identified.values.sum() >= 0
+    assert r.contact_screen.n_tested.values.sum() >= 0
+    assert r.tptdelivery.n_tpt_initiated.values.sum() >= 0
+
+
+def test_tpt_cascade_contacts_screened():
+    """Identified contacts are screened by contact_screen DxDelivery."""
+    sim = _make_cascade_sim(n_agents=2000)
+    sim.run()
+
+    r = sim.results
+    n_identified = r.householdcontacttracing.n_contacts_identified.values.sum()
+    n_screened = r.contact_screen.n_tested.values.sum()
+
+    # If contacts were identified, some should have been screened
+    if n_identified > 0:
+        assert n_screened > 0, \
+            f"Identified {n_identified} contacts but none were screened"
+
+
+def test_tpt_cascade_triage():
+    """Contacts are triaged: active TB → treatment, non-active → TPT."""
+    sim = _make_cascade_sim(n_agents=2000)
+    sim.run()
+
+    r = sim.results
+    n_contact_positive = r.contact_screen.n_positive.values.sum()
+    n_tpt = r.tptdelivery.n_tpt_initiated.values.sum()
+    n_treated = r.txdelivery.n_treated.values.sum()
+
+    # At least some contacts should get TPT or treatment
+    n_contact_screened = r.contact_screen.n_tested.values.sum()
+    if n_contact_screened > 0:
+        assert (n_tpt + n_contact_positive) > 0, \
+            f"Screened {n_contact_screened} contacts but none got TPT or treatment"

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -519,7 +519,7 @@ def test_tpt_sterilization_clears_infection():
 
     product = tbsim.TPTTx(
         p_sterilization=1.0, p_suppression=0.0,
-        pars={'dur_treatment': ss.constant(v=ss.days(7))},
+        pars={'dur_treatment': ss.constant(v=ss.days(0))},  # Instant treatment
     )
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
@@ -528,20 +528,25 @@ def test_tpt_sterilization_clears_infection():
     tpt = sim.interventions['tptsimple']
     tb_disease = sim.diseases.tb
 
-    # Run a few steps to initiate TPT and complete treatment
+    # Run steps to initiate TPT and resolve treatment completion
     for _ in range(5):
         tpt.step()
 
     # Agents who were in INFECTION and got sterilized should now be CLEARED
-    sterilized = tpt.product.tpt_sterilized.uids
-    if len(sterilized) > 0:
-        states = np.asarray(tb_disease.state[sterilized])
-        # Sterilized agents should be CLEARED (or may have been reinfected/progressed)
-        n_cleared = np.count_nonzero(states == tbsim.TBS.CLEARED)
-        assert n_cleared > 0, "Some sterilized agents should be in CLEARED state"
-        # None should be protected (suppression)
-        assert tpt.product.tpt_protected.count() == 0, \
-            "No agents should be in suppression protection with p_suppression=0"
+    resolved = tpt.product.tpt_resolved.uids
+    assert len(resolved) > 0, "Some agents should have been resolved"
+
+    # Check that sterilized agents with mechanism=STERILIZE are CLEARED
+    sterilize_mechs = tpt.product.tpt_mechanism[resolved] == tbsim.TPTTx.MECH_STERILIZE
+    sterilized = resolved[sterilize_mechs]
+    assert len(sterilized) > 0, "Some agents should have sterilization mechanism"
+    states = np.asarray(tb_disease.state[sterilized])
+    n_cleared = np.count_nonzero(states == tbsim.TBS.CLEARED)
+    assert n_cleared > 0, "Some sterilized agents should be in CLEARED state"
+
+    # None should be protected (suppression)
+    assert tpt.product.tpt_protected.count() == 0, \
+        "No agents should be in suppression protection with p_suppression=0"
 
 
 def test_tpt_suppression_applies_modifiers():
@@ -574,7 +579,7 @@ def test_tpt_suppression_applies_modifiers():
         assert np.any(current_activation[protected] < initial_activation[protected]), \
             "Suppression should reduce activation risk for protected agents"
     # No sterilized agents
-    assert tpt.product.tpt_sterilized.count() == 0
+    assert tpt.product.tpt_resolved.count() == 0
 
 
 def test_tpt_neither_gets_no_benefit():
@@ -597,7 +602,7 @@ def test_tpt_neither_gets_no_benefit():
 
     # No one should be protected or sterilized
     assert tpt.product.tpt_protected.count() == 0
-    assert tpt.product.tpt_sterilized.count() == 0
+    assert tpt.product.tpt_resolved.count() == 0
 
 
 def test_tpt_mechanisms_mutually_exclusive():
@@ -624,7 +629,7 @@ def test_tpt_mechanisms_mutually_exclusive():
     assert np.all(np.isin(initiated, [1, 2])), "Mechanisms should be 0, 1, or 2"
 
     # No agent should be both sterilized and protected
-    both = tpt.product.tpt_sterilized.uids.intersect(tpt.product.tpt_protected.uids)
+    both = tpt.product.tpt_resolved.uids.intersect(tpt.product.tpt_protected.uids)
     assert len(both) == 0, "No agent should have both sterilization and suppression"
 
 
@@ -653,10 +658,21 @@ def test_tpt_backward_compatible_defaults():
         assert np.all(mechs == tbsim.TPTTx.MECH_SUPPRESS), \
             "Default should assign all agents to suppression"
     # No sterilized agents
-    assert tpt.product.tpt_sterilized.count() == 0
+    assert tpt.product.tpt_resolved.count() == 0
 
 
 def test_tpt_invalid_probabilities():
     """Raise error if p_sterilization + p_suppression > 1."""
     with pytest.raises(ValueError, match="must be <= 1.0"):
         tbsim.TPTTx(p_sterilization=0.6, p_suppression=0.6)
+
+
+def test_tpt_mechanism_via_pars_dict():
+    """Mechanism probabilities can be passed via pars dict."""
+    product = tbsim.TPTTx(pars={'p_sterilization': 0.7, 'p_suppression': 0.3})
+    assert np.isclose(product.pars.p_sterilization, 0.7)
+    assert np.isclose(product.pars.p_suppression, 0.3)
+
+    # Also works via constructor args (existing path)
+    product2 = tbsim.TPTTx(p_sterilization=0.7, p_suppression=0.3)
+    assert np.isclose(product2.pars.p_sterilization, 0.7)

--- a/tests/test_tx_product.py
+++ b/tests/test_tx_product.py
@@ -27,8 +27,8 @@ def make_tx_sim(n_agents=200, tx_product=None):
 
 
 def test_tx_basic():
-    """Tx with efficacy=1.0 returns all agents as success."""
-    sim = make_tx_sim(tx_product=tbsim.Tx(efficacy=1.0))
+    """Tx with efficacy=1.0 and adherence=1.0 returns all agents as success."""
+    sim = make_tx_sim(tx_product=tbsim.Tx(efficacy=1.0, adherence=1.0))
     tx = sim.interventions.txdelivery.product
     for _ in range(10):
         sim.run_one_step()
@@ -43,7 +43,7 @@ def test_tx_basic():
 
 def test_tx_zero_efficacy():
     """Tx with efficacy=0.0 returns all agents as failure."""
-    sim = make_tx_sim(tx_product=tbsim.Tx(efficacy=0.0))
+    sim = make_tx_sim(tx_product=tbsim.Tx(efficacy=0.0, adherence=1.0))
     tx = sim.interventions.txdelivery.product
     for _ in range(10):
         sim.run_one_step()
@@ -54,20 +54,36 @@ def test_tx_zero_efficacy():
     assert len(results['failure']) == len(uids)
 
 
-def test_tx_drug_type_overrides_efficacy():
-    """Tx with drug_type overrides the efficacy parameter."""
+def test_tx_zero_adherence():
+    """Tx with adherence=0.0 returns all agents as failure regardless of efficacy."""
+    sim = make_tx_sim(tx_product=tbsim.Tx(efficacy=1.0, adherence=0.0))
+    tx = sim.interventions.txdelivery.product
+    for _ in range(10):
+        sim.run_one_step()
+
+    uids = sim.people.alive.uids[:20]
+    results = tx.administer(sim, uids)
+    assert len(results['success']) == 0
+    assert len(results['failure']) == len(uids)
+
+
+def test_tx_drug_type_overrides_params():
+    """Tx with drug_type overrides efficacy, adherence, and dur_treatment."""
     tx = tbsim.Tx(efficacy=0.5, drug_type='first_line_combo')
-    # first_line_combo has 95% cure rate, which should override 0.5
-    assert np.isclose(tx.efficacy, 0.95)
+    dp = tbsim.drug_params['first_line_combo']
+    # first_line_combo values should override the passed-in efficacy
+    assert np.isclose(tx.pars.p_success.pars.p, dp['cure_prob'])
+    assert np.isclose(tx.pars.p_adherence.pars.p, dp['adherence_rate'])
 
 
 def test_all_tx_products_in_sim():
-    """All Tx product classes can be instantiated and have expected efficacies."""
-    # Verify efficacies
-    assert np.isclose(tbsim.DOTS().efficacy, 0.85)
-    assert np.isclose(tbsim.DOTSImproved().efficacy, 0.90)
-    assert np.isclose(tbsim.FirstLine().efficacy, 0.95)
-    assert np.isclose(tbsim.SecondLine().efficacy, 0.75)
+    """All Tx product classes can be instantiated and run in a sim."""
+    # Verify dur_treatment from drug_params
+    dp = tbsim.drug_params
+    assert np.isclose(tbsim.DOTS().pars.dur_treatment.pars.v, dp['dots']['duration'])
+    assert np.isclose(tbsim.DOTSImproved().pars.dur_treatment.pars.v, dp['dots_improved']['duration'])
+    assert np.isclose(tbsim.FirstLine().pars.dur_treatment.pars.v, dp['first_line_combo']['duration'])
+    assert np.isclose(tbsim.SecondLine().pars.dur_treatment.pars.v, dp['second_line_combo']['duration'])
 
     # Verify one can be administered in a sim
     sim = make_tx_sim(tx_product=tbsim.DOTS())

--- a/tests/test_tx_product.py
+++ b/tests/test_tx_product.py
@@ -78,12 +78,12 @@ def test_tx_drug_type_overrides_params():
 
 def test_all_tx_products_in_sim():
     """All Tx product classes can be instantiated and run in a sim."""
-    # Verify dur_treatment from drug_params
+    # Verify dur_treatment from drug_params (stored in days)
     dp = tbsim.drug_params
-    assert np.isclose(tbsim.DOTS().pars.dur_treatment.pars.v, dp['dots']['duration'])
-    assert np.isclose(tbsim.DOTSImproved().pars.dur_treatment.pars.v, dp['dots_improved']['duration'])
-    assert np.isclose(tbsim.FirstLine().pars.dur_treatment.pars.v, dp['first_line_combo']['duration'])
-    assert np.isclose(tbsim.SecondLine().pars.dur_treatment.pars.v, dp['second_line_combo']['duration'])
+    assert np.isclose(tbsim.DOTS().pars.dur_treatment.pars.v, dp['dots']['duration'].days)
+    assert np.isclose(tbsim.DOTSImproved().pars.dur_treatment.pars.v, dp['dots_improved']['duration'].days)
+    assert np.isclose(tbsim.FirstLine().pars.dur_treatment.pars.v, dp['first_line_combo']['duration'].days)
+    assert np.isclose(tbsim.SecondLine().pars.dur_treatment.pars.v, dp['second_line_combo']['duration'].days)
 
     # Verify one can be administered in a sim
     sim = make_tx_sim(tx_product=tbsim.DOTS())


### PR DESCRIPTION
Treatment outcomes are no longer resolved instantly. Agents now stay in TREATMENT state with on_treatment=True for the full drug course duration (e.g. 180 days for DOTS), with outcomes pre-rolled at treatment start and resolved upon completion.

Changes:
- Tx product: added dur_treatment (from drug_params) and adherence roll; non-adherent agents are immediate failures before cure_prob is checked
- TxDelivery: new states ti_treatment_start, ti_treatment_end, pending_success, pending_failure; step_check_completion resolves outcomes only after dur_treatment elapses
- TPTHousehold contact tracing now works: on_treatment persists long enough for prev_on_treatment detection to trigger
- Updated run_tb_interventions.py example with TPT household demo