### PR TITLE
Add sterilization and suppression mechanisms to TPTTx

### DIFF
--- a/tbsim/interventions/interventions.py
+++ b/tbsim/interventions/interventions.py
@@ -95,24 +95,23 @@ class TBProductRoutine(ss.Intervention):
         Routine delivery step:
 
         1. Check date window.
-        2. Product handles internal phase transitions (``update_roster``).
-        3. Find and deliver to newly eligible agents.
-        4. Product applies ``rr_*`` modifiers for all currently protected.
+        2. Product handles internal phase transitions (``update_roster``) - even outside of date window
+        3. Find and deliver to newly eligible agents - only during date window
+        4. Product applies ``rr_*`` modifiers for all currently protected - even outside of date window
         """
         now = self.sim.now
         now_date = now.date() if hasattr(now, 'date') else now
-        if now_date < self.pars.start.date() or now_date > self.pars.stop.date():
-            return
-
+        
         # Product-internal transitions (expire protection, complete treatment, etc.)
         self.product.update_roster()
 
-        # Deliver to newly eligible
-        eligible = self.check_eligibility()
-        if len(eligible) > 0:
-            self.initiated[eligible] = True
-            self.ti_initiated[eligible] = self.ti
-            self.product.administer(self.sim.people, eligible)
+        # Deliver to newly eligible - only during date window
+        if now_date >= self.pars.start.date() and now_date <= self.pars.stop.date():
+            eligible = self.check_eligibility()
+            if len(eligible) > 0:
+                self.initiated[eligible] = True
+                self.ti_initiated[eligible] = self.ti
+                self.product.administer(self.sim.people, eligible)
 
         # Apply modifiers for all currently protected
         self.product.apply_protection()

--- a/tbsim/interventions/interventions.py
+++ b/tbsim/interventions/interventions.py
@@ -24,7 +24,7 @@ class TBProductRoutine(ss.Intervention):
     Args:
         product (ss.Vx): The vaccine/treatment product.
         coverage (ss.bernoulli): Fraction of eligible individuals who accept (applied once per person).
-        start / stop (ss.date): Campaign window.
+        start / stop (ss.date): Campaign window (defaults to sim start/stop if not provided).
         age_range (list or None): ``[min_age, max_age]`` filter, or ``None`` to skip.
         eligible_states (list or None): List of disease-state values (e.g. ``[TBS.INFECTION]``) to filter on,
             or ``None`` to skip.
@@ -37,8 +37,8 @@ class TBProductRoutine(ss.Intervention):
         super().__init__(**kwargs)
 
         self.define_pars(
-            start=ss.date('1900-01-01'),
-            stop=ss.date('2100-12-31'),
+            start=None,
+            stop=None,
             coverage=ss.bernoulli(p=0.5),
             age_range=None,
             eligible_states=None,
@@ -52,6 +52,15 @@ class TBProductRoutine(ss.Intervention):
             ss.BoolArr('initiated', default=False),
             ss.FloatArr('ti_initiated'),
         )
+        return
+
+    def init_pre(self, sim):
+        """Fill in start/stop from sim timeline if not explicitly set."""
+        if self.pars.start is None:
+            self.pars.start = sim.t.start
+        if self.pars.stop is None:
+            self.pars.stop = sim.t.stop
+        super().init_pre(sim)
         return
 
     def check_eligibility(self):

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -52,27 +52,14 @@ class TPTTx(ss.Product):
     MECH_STERILIZE = 1
     MECH_SUPPRESS = 2
 
-    def __init__(self, pars=None, p_sterilization=0.0, p_suppression=1.0, **kwargs):
+    def __init__(self, pars=None, **kwargs):
         """Initialize TPT product with mechanism probabilities and efficacy parameters."""
         super().__init__(**kwargs)
 
-        # Allow mechanism probabilities via pars dict or constructor args
-        pars = dict(pars) if pars else {}
-        p_sterilization = pars.pop('p_sterilization', p_sterilization)
-        p_suppression   = pars.pop('p_suppression', p_suppression)
-
-        # Validate mechanism probabilities
-        p_neither = 1.0 - p_sterilization - p_suppression
-        if p_neither < -1e-10:
-            raise ValueError(f"p_sterilization ({p_sterilization}) + p_suppression ({p_suppression}) must be <= 1.0")
-        p_neither = max(0.0, p_neither)  # Clamp rounding errors
-
         self.define_pars(
             disease='tb',
-            p_sterilization=p_sterilization,
-            p_suppression=p_suppression,
-            mechanism_dist=ss.choice(a=[self.MECH_NONE, self.MECH_STERILIZE, self.MECH_SUPPRESS],
-                                     p=[p_neither, p_sterilization, p_suppression]),
+            p_sterilization=0.0,
+            p_suppression=1.0,
             dur_treatment=ss.constant(v=ss.months(3)),
             dur_protection=ss.constant(v=ss.years(2)),
             activation_modifier=ss.uniform(0.3, 0.5),
@@ -81,6 +68,16 @@ class TPTTx(ss.Product):
             exclude_on_treatment=True,
         )
         self.update_pars(pars)
+
+        # Build mechanism_dist from final p_sterilization / p_suppression
+        p_sterilization = self.pars.p_sterilization
+        p_suppression   = self.pars.p_suppression
+        p_neither = 1.0 - p_sterilization - p_suppression
+        if p_neither < -1e-10:
+            raise ValueError(f"p_sterilization ({p_sterilization}) + p_suppression ({p_suppression}) must be <= 1.0")
+        p_neither = max(0.0, p_neither)  # Clamp rounding errors
+        self.pars.mechanism_dist = ss.choice(a=[self.MECH_NONE, self.MECH_STERILIZE, self.MECH_SUPPRESS],
+                                             p=[p_neither, p_sterilization, p_suppression])
 
         self.define_states(
             ss.IntArr('tpt_mechanism', default=self.MECH_NONE),

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -24,22 +24,18 @@ class TPTTx(ss.Product):
     """
     TPT treatment product with sterilization and suppression mechanisms.
 
-    Each agent receiving TPT is assigned one of three outcomes via a
-    multinomial draw (``ss.choice``):
+    TPT efficacy is modeled in two stages:
 
-    - **Sterilization** (``p_sterilization``): infection is cleared at
-      treatment completion (INFECTION → CLEARED). Only effective if the
-      agent is still in INFECTION state when treatment ends.
-    - **Suppression** (``p_suppression``): residual risk reduction via
-      ``rr_*`` modifiers during a post-treatment protection window.
-    - **Neither** (remainder): no benefit (e.g., non-adherent).
-
-    These are mutually exclusive; no agent gets both.
+    1. ``efficacy`` determines whether TPT works at all for a given agent.
+    2. Among efficacious agents, ``p_sterilize`` determines who gets
+       sterilization (infection cleared) vs suppression (risk reduction
+       via ``rr_*`` modifiers). These are mutually exclusive.
 
     Args:
         disease (str): Key of the disease module to target (default ``'tb'``).
-        p_sterilization (float): Probability of sterilization benefit (default 0.0).
-        p_suppression (float): Probability of suppression benefit (default 1.0).
+        efficacy (ss.bernoulli): Probability that TPT works (default 0.6).
+        p_sterilize (ss.bernoulli): Among efficacious agents, probability of
+            sterilization vs suppression (default 0.0 = all suppression).
         dur_treatment (ss.Dist): Duration of the antibiotic course (default 3 months).
         dur_protection (ss.Dist): Duration of post-treatment protection (default 2 years).
         activation_modifier / clearance_modifier / death_modifier (ss.Dist):
@@ -58,8 +54,8 @@ class TPTTx(ss.Product):
 
         self.define_pars(
             disease='tb',
-            p_sterilization=0.0,
-            p_suppression=1.0,
+            efficacy=ss.bernoulli(p=0.6),
+            p_sterilize=ss.bernoulli(p=0.0),
             dur_treatment=ss.constant(v=ss.months(3)),
             dur_protection=ss.constant(v=ss.years(2)),
             activation_modifier=ss.uniform(0.3, 0.5),
@@ -68,16 +64,6 @@ class TPTTx(ss.Product):
             exclude_on_treatment=True,
         )
         self.update_pars(pars)
-
-        # Build mechanism_dist from final p_sterilization / p_suppression
-        p_sterilization = self.pars.p_sterilization
-        p_suppression   = self.pars.p_suppression
-        p_neither = 1.0 - p_sterilization - p_suppression
-        if p_neither < -1e-10:
-            raise ValueError(f"p_sterilization ({p_sterilization}) + p_suppression ({p_suppression}) must be <= 1.0")
-        p_neither = max(0.0, p_neither)  # Clamp rounding errors
-        self.pars.mechanism_dist = ss.choice(a=[self.MECH_NONE, self.MECH_STERILIZE, self.MECH_SUPPRESS],
-                                             p=[p_neither, p_sterilization, p_suppression])
 
         self.define_states(
             ss.IntArr('tpt_mechanism', default=self.MECH_NONE),
@@ -118,17 +104,19 @@ class TPTTx(ss.Product):
         if len(uids) == 0:
             return ss.uids()
 
-        # Roll mechanism assignment
-        mechanism = self.pars.mechanism_dist.rvs(uids)
-        self.tpt_mechanism[uids] = mechanism
+        # Draw 1: is TPT effective?
+        effective, ineffective = self.pars.efficacy.filter(uids, both=True)
+        self.tpt_mechanism[ineffective] = self.MECH_NONE
+
+        # Draw 2: among effective agents, sterilization or suppression?
+        sterilize, suppress = self.pars.p_sterilize.filter(effective, both=True)
+        self.tpt_mechanism[sterilize] = self.MECH_STERILIZE
+        self.tpt_mechanism[suppress]  = self.MECH_SUPPRESS
 
         # Schedule treatment duration for all agents (ti_protection_starts is used
         # by update_roster to detect treatment completion, regardless of mechanism)
         dur_tx = self.pars.dur_treatment.rvs(uids)
         self.ti_protection_starts[uids] = self.ti + dur_tx
-
-        # Suppression agents also need protection window and rr_* modifiers
-        suppress = uids[mechanism == self.MECH_SUPPRESS]
         if len(suppress) > 0:
             dur_prot = self.pars.dur_protection.rvs(suppress)
             self.ti_protection_expires[suppress] = self.ti_protection_starts[suppress] + dur_prot

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -56,6 +56,11 @@ class TPTTx(ss.Product):
         """Initialize TPT product with mechanism probabilities and efficacy parameters."""
         super().__init__(**kwargs)
 
+        # Allow mechanism probabilities via pars dict or constructor args
+        pars = dict(pars) if pars else {}
+        p_sterilization = pars.pop('p_sterilization', p_sterilization)
+        p_suppression   = pars.pop('p_suppression', p_suppression)
+
         # Validate mechanism probabilities
         p_neither = 1.0 - p_sterilization - p_suppression
         if p_neither < -1e-10:
@@ -80,7 +85,7 @@ class TPTTx(ss.Product):
         self.define_states(
             ss.IntArr('tpt_mechanism', default=self.MECH_NONE),
             ss.BoolArr('tpt_protected', default=False),
-            ss.BoolArr('tpt_sterilized', default=False),
+            ss.BoolArr('tpt_resolved', default=False),
             ss.FloatArr('ti_protection_starts'),
             ss.FloatArr('ti_protection_expires'),
             ss.FloatArr('tpt_activation_modifier_applied'),
@@ -120,7 +125,8 @@ class TPTTx(ss.Product):
         mechanism = self.pars.mechanism_dist.rvs(uids)
         self.tpt_mechanism[uids] = mechanism
 
-        # Schedule treatment duration for all agents
+        # Schedule treatment duration for all agents (ti_protection_starts is used
+        # by update_roster to detect treatment completion, regardless of mechanism)
         dur_tx = self.pars.dur_treatment.rvs(uids)
         self.ti_protection_starts[uids] = self.ti + dur_tx
 
@@ -147,7 +153,7 @@ class TPTTx(ss.Product):
         Also expires protection for suppression agents past their window.
         """
         # Find agents whose treatment just completed
-        not_yet_resolved = (~self.tpt_protected & ~self.tpt_sterilized).uids
+        not_yet_resolved = (~self.tpt_protected & ~self.tpt_resolved).uids
         if len(not_yet_resolved) > 0:
             starts = self.ti_protection_starts[not_yet_resolved]
             ready = not_yet_resolved[~np.isnan(starts) & (self.ti >= starts)]
@@ -165,6 +171,11 @@ class TPTTx(ss.Product):
                 if len(suppress_uids) > 0:
                     self.tpt_protected[suppress_uids] = True
 
+                # Neither: mark as resolved so they aren't re-checked each step
+                neither_uids = ready[mechs == self.MECH_NONE]
+                if len(neither_uids) > 0:
+                    self.tpt_resolved[neither_uids] = True
+
         # Expire protection for suppression agents
         protected_uids = self.tpt_protected.uids
         if len(protected_uids) > 0:
@@ -181,7 +192,7 @@ class TPTTx(ss.Product):
         # Only sterilize agents still latently infected
         still_infected = uids[tb.state[uids] == TBS.INFECTION]
         if len(still_infected) == 0:
-            self.tpt_sterilized[uids] = True  # Mark as resolved even if no effect
+            self.tpt_resolved[uids] = True  # Mark as resolved even if no effect
             return
 
         # Clear infection (same pattern as TxDelivery.step_start_treatment)
@@ -192,7 +203,7 @@ class TPTTx(ss.Product):
         tb.infected[still_infected] = False
         tb.susceptible[still_infected] = True
 
-        self.tpt_sterilized[uids] = True
+        self.tpt_resolved[uids] = True
         return
 
     def apply_protection(self):

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -63,8 +63,8 @@ class TPTTx(ss.Product):
             dur_treatment=ss.constant(v=ss.months(3)),
             dur_protection=ss.constant(v=ss.years(2)),
             activation_modifier=ss.uniform(0.3, 0.5),
-            clearance_modifier=ss.uniform(1.2, 1.4),
-            death_modifier=ss.uniform(0.1, 0.3),
+            clearance_modifier=ss.uniform(1.0, 1.0),
+            death_modifier=ss.uniform(1.0, 1.0),
             exclude_on_treatment=True,
         )
         self.update_pars(pars)

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -22,27 +22,52 @@ __all__ = ['TPTTx', 'TPTSimple', 'TPTHousehold', 'HouseholdContactTracing', 'TPT
 
 class TPTTx(ss.Product):
     """
-    TPT treatment product.
+    TPT treatment product with sterilization and suppression mechanisms.
 
-    Models a two-phase intervention: a **treatment phase** (antibiotic course)
-    followed by a **protection phase** (residual risk reduction via ``rr_*``
-    modifiers).  During treatment, no protection is applied; after treatment
-    completes, ``rr_activation``, ``rr_clearance``, and ``rr_death`` are
-    modified each step until protection expires.
+    Each agent receiving TPT is assigned one of three outcomes via a
+    multinomial draw (``ss.choice``):
+
+    - **Sterilization** (``p_sterilization``): infection is cleared at
+      treatment completion (INFECTION → CLEARED). Only effective if the
+      agent is still in INFECTION state when treatment ends.
+    - **Suppression** (``p_suppression``): residual risk reduction via
+      ``rr_*`` modifiers during a post-treatment protection window.
+    - **Neither** (remainder): no benefit (e.g., non-adherent).
+
+    These are mutually exclusive; no agent gets both.
 
     Args:
         disease (str): Key of the disease module to target (default ``'tb'``).
+        p_sterilization (float): Probability of sterilization benefit (default 0.0).
+        p_suppression (float): Probability of suppression benefit (default 1.0).
         dur_treatment (ss.Dist): Duration of the antibiotic course (default 3 months).
         dur_protection (ss.Dist): Duration of post-treatment protection (default 2 years).
-        activation_modifier / clearance_modifier / death_modifier (ss.Dist): Per-individual risk-modifier distributions.
+        activation_modifier / clearance_modifier / death_modifier (ss.Dist):
+            Per-individual risk-modifier distributions (suppression only).
         exclude_on_treatment (bool): If True, skip agents currently on TB treatment (default True).
     """
 
-    def __init__(self, pars=None, **kwargs):
-        """Initialize TPT product with default treatment duration and efficacy parameters."""
+    # Mechanism constants
+    MECH_NONE = 0
+    MECH_STERILIZE = 1
+    MECH_SUPPRESS = 2
+
+    def __init__(self, pars=None, p_sterilization=0.0, p_suppression=1.0, **kwargs):
+        """Initialize TPT product with mechanism probabilities and efficacy parameters."""
         super().__init__(**kwargs)
+
+        # Validate mechanism probabilities
+        p_neither = 1.0 - p_sterilization - p_suppression
+        if p_neither < -1e-10:
+            raise ValueError(f"p_sterilization ({p_sterilization}) + p_suppression ({p_suppression}) must be <= 1.0")
+        p_neither = max(0.0, p_neither)  # Clamp rounding errors
+
         self.define_pars(
             disease='tb',
+            p_sterilization=p_sterilization,
+            p_suppression=p_suppression,
+            mechanism_dist=ss.choice(a=[self.MECH_NONE, self.MECH_STERILIZE, self.MECH_SUPPRESS],
+                                     p=[p_neither, p_sterilization, p_suppression]),
             dur_treatment=ss.constant(v=ss.months(3)),
             dur_protection=ss.constant(v=ss.years(2)),
             activation_modifier=ss.uniform(0.3, 0.5),
@@ -53,7 +78,9 @@ class TPTTx(ss.Product):
         self.update_pars(pars)
 
         self.define_states(
+            ss.IntArr('tpt_mechanism', default=self.MECH_NONE),
             ss.BoolArr('tpt_protected', default=False),
+            ss.BoolArr('tpt_sterilized', default=False),
             ss.FloatArr('ti_protection_starts'),
             ss.FloatArr('ti_protection_expires'),
             ss.FloatArr('tpt_activation_modifier_applied'),
@@ -66,9 +93,9 @@ class TPTTx(ss.Product):
         """
         Start TPT for *uids*.
 
-        Filters out ineligible agents (already on TB treatment, already
-        protected), then samples per-agent modifiers and schedules the
-        protection window.
+        Filters out ineligible agents, rolls mechanism assignment
+        (sterilization / suppression / neither), schedules treatment
+        duration, and samples rr_* modifiers for suppression agents.
 
         Returns:
             ss.uids: UIDs of agents who actually started TPT.
@@ -89,33 +116,56 @@ class TPTTx(ss.Product):
         if len(uids) == 0:
             return ss.uids()
 
+        # Roll mechanism assignment
+        mechanism = self.pars.mechanism_dist.rvs(uids)
+        self.tpt_mechanism[uids] = mechanism
+
+        # Schedule treatment duration for all agents
         dur_tx = self.pars.dur_treatment.rvs(uids)
-        dur_prot = self.pars.dur_protection.rvs(uids)
-
         self.ti_protection_starts[uids] = self.ti + dur_tx
-        self.ti_protection_expires[uids] = self.ti + dur_tx + dur_prot
 
-        self.tpt_activation_modifier_applied[uids] = self.pars.activation_modifier.rvs(uids)
-        self.tpt_clearance_modifier_applied[uids] = self.pars.clearance_modifier.rvs(uids)
-        self.tpt_death_modifier_applied[uids] = self.pars.death_modifier.rvs(uids)
+        # Suppression agents also need protection window and rr_* modifiers
+        suppress = uids[mechanism == self.MECH_SUPPRESS]
+        if len(suppress) > 0:
+            dur_prot = self.pars.dur_protection.rvs(suppress)
+            self.ti_protection_expires[suppress] = self.ti_protection_starts[suppress] + dur_prot
+            self.tpt_activation_modifier_applied[suppress] = self.pars.activation_modifier.rvs(suppress)
+            self.tpt_clearance_modifier_applied[suppress] = self.pars.clearance_modifier.rvs(suppress)
+            self.tpt_death_modifier_applied[suppress] = self.pars.death_modifier.rvs(suppress)
 
         return uids
 
     def update_roster(self):
         """
-        Start protection for agents whose treatment completed;
-        expire protection for agents past their expiry time.
-        """
-        # Start protection for agents whose treatment just completed
-        not_yet_protected = (~self.tpt_protected).uids
-        if len(not_yet_protected) > 0:
-            starts = self.ti_protection_starts[not_yet_protected]
-            ready = not_yet_protected[
-                ~np.isnan(starts) & (self.ti >= starts)
-            ]
-            self.tpt_protected[ready] = True
+        Handle treatment completion by mechanism:
 
-        # Expire protection
+        - **Sterilization**: clear infection (INFECTION → CLEARED) if agent
+          is still latently infected.
+        - **Suppression**: start rr_* protection phase.
+        - **Neither**: no action.
+
+        Also expires protection for suppression agents past their window.
+        """
+        # Find agents whose treatment just completed
+        not_yet_resolved = (~self.tpt_protected & ~self.tpt_sterilized).uids
+        if len(not_yet_resolved) > 0:
+            starts = self.ti_protection_starts[not_yet_resolved]
+            ready = not_yet_resolved[~np.isnan(starts) & (self.ti >= starts)]
+
+            if len(ready) > 0:
+                mechs = self.tpt_mechanism[ready]
+
+                # Sterilization: clear infection if still in INFECTION state
+                sterilize_uids = ready[mechs == self.MECH_STERILIZE]
+                if len(sterilize_uids) > 0:
+                    self._apply_sterilization(sterilize_uids)
+
+                # Suppression: start protection phase
+                suppress_uids = ready[mechs == self.MECH_SUPPRESS]
+                if len(suppress_uids) > 0:
+                    self.tpt_protected[suppress_uids] = True
+
+        # Expire protection for suppression agents
         protected_uids = self.tpt_protected.uids
         if len(protected_uids) > 0:
             expired = protected_uids[
@@ -124,8 +174,29 @@ class TPTTx(ss.Product):
             self.tpt_protected[expired] = False
         return
 
+    def _apply_sterilization(self, uids):
+        """Clear infection for sterilization agents still in INFECTION state."""
+        tb = self.sim.diseases[self.pars.disease]
+
+        # Only sterilize agents still latently infected
+        still_infected = uids[tb.state[uids] == TBS.INFECTION]
+        if len(still_infected) == 0:
+            self.tpt_sterilized[uids] = True  # Mark as resolved even if no effect
+            return
+
+        # Clear infection (same pattern as TxDelivery.step_start_treatment)
+        tb.state[still_infected] = TBS.CLEARED
+        tb.rr_reinfection[still_infected] = tb.pars.rr_reinfection_cleared
+        if tb.pars.dur_reinfection_protection is not None:
+            tb.ti_rr_reinfection_wane[still_infected] = self.ti + tb.pars.dur_reinfection_protection.rvs(still_infected)
+        tb.infected[still_infected] = False
+        tb.susceptible[still_infected] = True
+
+        self.tpt_sterilized[uids] = True
+        return
+
     def apply_protection(self):
-        """Multiply ``rr_*`` arrays for all currently protected agents."""
+        """Multiply ``rr_*`` arrays for all currently protected (suppression) agents."""
         protected = self.tpt_protected.uids
         if len(protected) > 0:
             tb = self.sim.diseases[self.pars.disease]

--- a/tbsim/tb.py
+++ b/tbsim/tb.py
@@ -147,7 +147,7 @@ class TB(BaseTB):
             trans_asymp=0.82,                   # κ kappa: rel. transmissibility asymptomatic vs symptomatic
             rr_reinfection_rec=0.21,            # π pi: RR reinfection after NON_INFECTIOUS → CLEARED
             rr_reinfection_treat=3.15,          # ρ rho: RR reinfection after TREATMENT → CLEARED
-            rr_reinfection_cleared=1.0,         # RR reinfection after INFECTION → CLEARED (latent cleared)
+            rr_reinfection_cleared=1.0,         # RR reinfection after INFECTION → CLEARED (latent cleared); also applies to agents cleared via TPT sterilization
             dur_reinfection_protection=None,    # Distribution of protection duration; None = never wanes
             # --- From INFECTION (latent) ---
             inf_cle=ss.peryear(1.90),            # Clear infection (no active TB)

--- a/tests/test_bcg.py
+++ b/tests/test_bcg.py
@@ -39,8 +39,8 @@ def test_bcg_default_values():
 
     # Delivery pars on the intervention
     assert '0.5' in str(bcg.pars.coverage) or '0.50' in str(bcg.pars.coverage)
-    assert bcg.pars.start == ss.date('1900-01-01')
-    assert bcg.pars.stop == ss.date('2100-12-31')
+    assert bcg.pars.start == sim.pars.start
+    assert bcg.pars.stop == sim.pars.stop
     assert bcg.pars.age_range == [0, 5]
 
     # Biological pars on the product

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -517,10 +517,10 @@ def test_tpt_sterilization_clears_infection():
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
-    product = tbsim.TPTTx(
-        p_sterilization=1.0, p_suppression=0.0,
-        pars={'dur_treatment': ss.constant(v=ss.days(0))},  # Instant treatment
-    )
+    product = tbsim.TPTTx(pars={
+        'p_sterilization': 1.0, 'p_suppression': 0.0,
+        'dur_treatment': ss.constant(v=ss.days(0)),  # Instant treatment
+    })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
     sim.init()
@@ -555,13 +555,11 @@ def test_tpt_suppression_applies_modifiers():
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
-    product = tbsim.TPTTx(
-        p_sterilization=0.0, p_suppression=1.0,
-        pars={
-            'dur_treatment': ss.constant(v=ss.days(0)),
-            'dur_protection': ss.constant(v=ss.years(10)),
-        },
-    )
+    product = tbsim.TPTTx(pars={
+        'p_sterilization': 0.0, 'p_suppression': 1.0,
+        'dur_treatment': ss.constant(v=ss.days(0)),
+        'dur_protection': ss.constant(v=ss.years(10)),
+    })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
     sim.init()
@@ -588,10 +586,10 @@ def test_tpt_neither_gets_no_benefit():
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
-    product = tbsim.TPTTx(
-        p_sterilization=0.0, p_suppression=0.0,
-        pars={'dur_treatment': ss.constant(v=ss.days(7))},
-    )
+    product = tbsim.TPTTx(pars={
+        'p_sterilization': 0.0, 'p_suppression': 0.0,
+        'dur_treatment': ss.constant(v=ss.days(7)),
+    })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
     sim.init()
@@ -611,10 +609,10 @@ def test_tpt_mechanisms_mutually_exclusive():
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
-    product = tbsim.TPTTx(
-        p_sterilization=0.5, p_suppression=0.5,
-        pars={'dur_treatment': ss.constant(v=ss.days(7))},
-    )
+    product = tbsim.TPTTx(pars={
+        'p_sterilization': 0.5, 'p_suppression': 0.5,
+        'dur_treatment': ss.constant(v=ss.days(7)),
+    })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
     sim.init()
@@ -664,7 +662,7 @@ def test_tpt_backward_compatible_defaults():
 def test_tpt_invalid_probabilities():
     """Raise error if p_sterilization + p_suppression > 1."""
     with pytest.raises(ValueError, match="must be <= 1.0"):
-        tbsim.TPTTx(p_sterilization=0.6, p_suppression=0.6)
+        tbsim.TPTTx(pars={'p_sterilization': 0.6, 'p_suppression': 0.6})
 
 
 def test_tpt_mechanism_via_pars_dict():
@@ -672,7 +670,3 @@ def test_tpt_mechanism_via_pars_dict():
     product = tbsim.TPTTx(pars={'p_sterilization': 0.7, 'p_suppression': 0.3})
     assert np.isclose(product.pars.p_sterilization, 0.7)
     assert np.isclose(product.pars.p_suppression, 0.3)
-
-    # Also works via constructor args (existing path)
-    product2 = tbsim.TPTTx(p_sterilization=0.7, p_suppression=0.3)
-    assert np.isclose(product2.pars.p_sterilization, 0.7)

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -518,7 +518,7 @@ def test_tpt_sterilization_clears_infection():
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
     product = tbsim.TPTTx(pars={
-        'p_sterilization': 1.0, 'p_suppression': 0.0,
+        'efficacy': ss.bernoulli(p=1.0), 'p_sterilize': ss.bernoulli(p=1.0),
         'dur_treatment': ss.constant(v=ss.days(0)),  # Instant treatment
     })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
@@ -546,7 +546,7 @@ def test_tpt_sterilization_clears_infection():
 
     # None should be protected (suppression)
     assert tpt.product.tpt_protected.count() == 0, \
-        "No agents should be in suppression protection with p_suppression=0"
+        "No agents should be in suppression protection with p_sterilization=1"
 
 
 def test_tpt_suppression_applies_modifiers():
@@ -556,7 +556,7 @@ def test_tpt_suppression_applies_modifiers():
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
     product = tbsim.TPTTx(pars={
-        'p_sterilization': 0.0, 'p_suppression': 1.0,
+        'efficacy': ss.bernoulli(p=1.0),
         'dur_treatment': ss.constant(v=ss.days(0)),
         'dur_protection': ss.constant(v=ss.years(10)),
     })
@@ -587,7 +587,7 @@ def test_tpt_neither_gets_no_benefit():
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
     product = tbsim.TPTTx(pars={
-        'p_sterilization': 0.0, 'p_suppression': 0.0,
+        'efficacy': ss.bernoulli(p=0.0),
         'dur_treatment': ss.constant(v=ss.days(7)),
     })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
@@ -610,7 +610,7 @@ def test_tpt_mechanisms_mutually_exclusive():
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
     product = tbsim.TPTTx(pars={
-        'p_sterilization': 0.5, 'p_suppression': 0.5,
+        'efficacy': ss.bernoulli(p=1.0), 'p_sterilize': ss.bernoulli(p=0.5),
         'dur_treatment': ss.constant(v=ss.days(7)),
     })
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
@@ -631,9 +631,9 @@ def test_tpt_mechanisms_mutually_exclusive():
     assert len(both) == 0, "No agent should have both sterilization and suppression"
 
 
-def test_tpt_backward_compatible_defaults():
-    """Default params (p_sterilization=0, p_suppression=1) produce suppression-only behavior."""
-    nagents = 100
+def test_tpt_default_efficacy():
+    """Default params (efficacy=0.6, p_sterilize=0) produce suppression or nothing."""
+    nagents = 200
     pop, tb, net, pars = make_modules(agents=nagents)
     pop = ss.People(n_agents=nagents, age_data=age_data)
 
@@ -649,24 +649,24 @@ def test_tpt_backward_compatible_defaults():
     tpt.step()
     tpt.step()
 
-    # All initiated agents should have suppression mechanism
+    # With default p_sterilize=0, mechanisms should be SUPPRESS or NONE only
     initiated = tpt.initiated.uids
     if len(initiated) > 0:
         mechs = np.asarray(tpt.product.tpt_mechanism[initiated])
-        assert np.all(mechs == tbsim.TPTTx.MECH_SUPPRESS), \
-            "Default should assign all agents to suppression"
-    # No sterilized agents
-    assert tpt.product.tpt_resolved.count() == 0
-
-
-def test_tpt_invalid_probabilities():
-    """Raise error if p_sterilization + p_suppression > 1."""
-    with pytest.raises(ValueError, match="must be <= 1.0"):
-        tbsim.TPTTx(pars={'p_sterilization': 0.6, 'p_suppression': 0.6})
+        assert np.all(np.isin(mechs, [tbsim.TPTTx.MECH_NONE, tbsim.TPTTx.MECH_SUPPRESS])), \
+            "Default should assign agents to suppression or nothing (no sterilization)"
+        # Some should be protected (suppression) and some resolved (no benefit)
+        n_suppress = np.count_nonzero(mechs == tbsim.TPTTx.MECH_SUPPRESS)
+        n_none     = np.count_nonzero(mechs == tbsim.TPTTx.MECH_NONE)
+        assert n_suppress > 0, "Some agents should get suppression"
+        assert n_none > 0, "Some agents should get no benefit (efficacy < 1)"
 
 
 def test_tpt_mechanism_via_pars_dict():
     """Mechanism probabilities can be passed via pars dict."""
-    product = tbsim.TPTTx(pars={'p_sterilization': 0.7, 'p_suppression': 0.3})
-    assert np.isclose(product.pars.p_sterilization, 0.7)
-    assert np.isclose(product.pars.p_suppression, 0.3)
+    product = tbsim.TPTTx(pars={
+        'efficacy': ss.bernoulli(p=0.8),
+        'p_sterilize': ss.bernoulli(p=0.3),
+    })
+    assert np.isclose(product.pars.efficacy.pars.p, 0.8)
+    assert np.isclose(product.pars.p_sterilize.pars.p, 0.3)

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -505,3 +505,158 @@ def test_tpt_cascade_triage():
     if n_contact_screened > 0:
         assert (n_tpt + n_contact_positive) > 0, \
             f"Screened {n_contact_screened} contacts but none got TPT or treatment"
+
+
+# ---------------------------------------------------------------------------
+# Sterilization / suppression mechanism tests
+# ---------------------------------------------------------------------------
+
+def test_tpt_sterilization_clears_infection():
+    """Agents with sterilization mechanism move from INFECTION → CLEARED after treatment."""
+    nagents = 200
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(
+        p_sterilization=1.0, p_suppression=0.0,
+        pars={'dur_treatment': ss.constant(v=ss.days(7))},
+    )
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tpt = sim.interventions['tptsimple']
+    tb_disease = sim.diseases.tb
+
+    # Run a few steps to initiate TPT and complete treatment
+    for _ in range(5):
+        tpt.step()
+
+    # Agents who were in INFECTION and got sterilized should now be CLEARED
+    sterilized = tpt.product.tpt_sterilized.uids
+    if len(sterilized) > 0:
+        states = np.asarray(tb_disease.state[sterilized])
+        # Sterilized agents should be CLEARED (or may have been reinfected/progressed)
+        n_cleared = np.count_nonzero(states == tbsim.TBS.CLEARED)
+        assert n_cleared > 0, "Some sterilized agents should be in CLEARED state"
+        # None should be protected (suppression)
+        assert tpt.product.tpt_protected.count() == 0, \
+            "No agents should be in suppression protection with p_suppression=0"
+
+
+def test_tpt_suppression_applies_modifiers():
+    """Agents with suppression mechanism get rr_* modifiers (existing behavior)."""
+    nagents = 200
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(
+        p_sterilization=0.0, p_suppression=1.0,
+        pars={
+            'dur_treatment': ss.constant(v=ss.days(0)),
+            'dur_protection': ss.constant(v=ss.years(10)),
+        },
+    )
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tb_disease = sim.diseases.tb
+    initial_activation = np.array(tb_disease.rr_activation).copy()
+
+    tpt = sim.interventions['tptsimple']
+    tpt.step()
+    tpt.step()
+
+    current_activation = np.array(tb_disease.rr_activation)
+    protected = tpt.product.tpt_protected.uids
+    if len(protected) > 0:
+        assert np.any(current_activation[protected] < initial_activation[protected]), \
+            "Suppression should reduce activation risk for protected agents"
+    # No sterilized agents
+    assert tpt.product.tpt_sterilized.count() == 0
+
+
+def test_tpt_neither_gets_no_benefit():
+    """Agents with mechanism=NONE stay in INFECTION with no modifiers."""
+    nagents = 200
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(
+        p_sterilization=0.0, p_suppression=0.0,
+        pars={'dur_treatment': ss.constant(v=ss.days(7))},
+    )
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tpt = sim.interventions['tptsimple']
+    for _ in range(5):
+        tpt.step()
+
+    # No one should be protected or sterilized
+    assert tpt.product.tpt_protected.count() == 0
+    assert tpt.product.tpt_sterilized.count() == 0
+
+
+def test_tpt_mechanisms_mutually_exclusive():
+    """No agent has both sterilization and suppression."""
+    nagents = 200
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(
+        p_sterilization=0.5, p_suppression=0.5,
+        pars={'dur_treatment': ss.constant(v=ss.days(7))},
+    )
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tpt = sim.interventions['tptsimple']
+    for _ in range(5):
+        tpt.step()
+
+    # Check that mechanisms are 0, 1, or 2 only
+    mechs = np.asarray(tpt.product.tpt_mechanism)
+    initiated = mechs[mechs != 0]
+    assert np.all(np.isin(initiated, [1, 2])), "Mechanisms should be 0, 1, or 2"
+
+    # No agent should be both sterilized and protected
+    both = tpt.product.tpt_sterilized.uids.intersect(tpt.product.tpt_protected.uids)
+    assert len(both) == 0, "No agent should have both sterilization and suppression"
+
+
+def test_tpt_backward_compatible_defaults():
+    """Default params (p_sterilization=0, p_suppression=1) produce suppression-only behavior."""
+    nagents = 100
+    pop, tb, net, pars = make_modules(agents=nagents)
+    pop = ss.People(n_agents=nagents, age_data=age_data)
+
+    product = tbsim.TPTTx(pars={
+        'dur_treatment': ss.constant(v=ss.days(0)),
+        'dur_protection': ss.constant(v=ss.years(10)),
+    })
+    itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
+    sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
+    sim.init()
+
+    tpt = sim.interventions['tptsimple']
+    tpt.step()
+    tpt.step()
+
+    # All initiated agents should have suppression mechanism
+    initiated = tpt.initiated.uids
+    if len(initiated) > 0:
+        mechs = np.asarray(tpt.product.tpt_mechanism[initiated])
+        assert np.all(mechs == tbsim.TPTTx.MECH_SUPPRESS), \
+            "Default should assign all agents to suppression"
+    # No sterilized agents
+    assert tpt.product.tpt_sterilized.count() == 0
+
+
+def test_tpt_invalid_probabilities():
+    """Raise error if p_sterilization + p_suppression > 1."""
+    with pytest.raises(ValueError, match="must be <= 1.0"):
+        tbsim.TPTTx(p_sterilization=0.6, p_suppression=0.6)

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -519,7 +519,7 @@ def test_tpt_sterilization_clears_infection():
 
     product = tbsim.TPTTx(
         p_sterilization=1.0, p_suppression=0.0,
-        pars={'dur_treatment': ss.constant(v=ss.days(7))},
+        pars={'dur_treatment': ss.constant(v=ss.days(0))},  # Instant treatment
     )
     itv = tbsim.TPTSimple(product=product, pars={'coverage': 1.0})
     sim = ss.Sim(people=pop, diseases=tb, interventions=itv, networks=net, pars=pars)
@@ -528,20 +528,25 @@ def test_tpt_sterilization_clears_infection():
     tpt = sim.interventions['tptsimple']
     tb_disease = sim.diseases.tb
 
-    # Run a few steps to initiate TPT and complete treatment
+    # Run steps to initiate TPT and resolve treatment completion
     for _ in range(5):
         tpt.step()
 
     # Agents who were in INFECTION and got sterilized should now be CLEARED
-    sterilized = tpt.product.tpt_sterilized.uids
-    if len(sterilized) > 0:
-        states = np.asarray(tb_disease.state[sterilized])
-        # Sterilized agents should be CLEARED (or may have been reinfected/progressed)
-        n_cleared = np.count_nonzero(states == tbsim.TBS.CLEARED)
-        assert n_cleared > 0, "Some sterilized agents should be in CLEARED state"
-        # None should be protected (suppression)
-        assert tpt.product.tpt_protected.count() == 0, \
-            "No agents should be in suppression protection with p_suppression=0"
+    resolved = tpt.product.tpt_resolved.uids
+    assert len(resolved) > 0, "Some agents should have been resolved"
+
+    # Check that sterilized agents with mechanism=STERILIZE are CLEARED
+    sterilize_mechs = tpt.product.tpt_mechanism[resolved] == tbsim.TPTTx.MECH_STERILIZE
+    sterilized = resolved[sterilize_mechs]
+    assert len(sterilized) > 0, "Some agents should have sterilization mechanism"
+    states = np.asarray(tb_disease.state[sterilized])
+    n_cleared = np.count_nonzero(states == tbsim.TBS.CLEARED)
+    assert n_cleared > 0, "Some sterilized agents should be in CLEARED state"
+
+    # None should be protected (suppression)
+    assert tpt.product.tpt_protected.count() == 0, \
+        "No agents should be in suppression protection with p_suppression=0"
 
 
 def test_tpt_suppression_applies_modifiers():
@@ -574,7 +579,7 @@ def test_tpt_suppression_applies_modifiers():
         assert np.any(current_activation[protected] < initial_activation[protected]), \
             "Suppression should reduce activation risk for protected agents"
     # No sterilized agents
-    assert tpt.product.tpt_sterilized.count() == 0
+    assert tpt.product.tpt_resolved.count() == 0
 
 
 def test_tpt_neither_gets_no_benefit():
@@ -597,7 +602,7 @@ def test_tpt_neither_gets_no_benefit():
 
     # No one should be protected or sterilized
     assert tpt.product.tpt_protected.count() == 0
-    assert tpt.product.tpt_sterilized.count() == 0
+    assert tpt.product.tpt_resolved.count() == 0
 
 
 def test_tpt_mechanisms_mutually_exclusive():
@@ -624,7 +629,7 @@ def test_tpt_mechanisms_mutually_exclusive():
     assert np.all(np.isin(initiated, [1, 2])), "Mechanisms should be 0, 1, or 2"
 
     # No agent should be both sterilized and protected
-    both = tpt.product.tpt_sterilized.uids.intersect(tpt.product.tpt_protected.uids)
+    both = tpt.product.tpt_resolved.uids.intersect(tpt.product.tpt_protected.uids)
     assert len(both) == 0, "No agent should have both sterilization and suppression"
 
 
@@ -653,10 +658,21 @@ def test_tpt_backward_compatible_defaults():
         assert np.all(mechs == tbsim.TPTTx.MECH_SUPPRESS), \
             "Default should assign all agents to suppression"
     # No sterilized agents
-    assert tpt.product.tpt_sterilized.count() == 0
+    assert tpt.product.tpt_resolved.count() == 0
 
 
 def test_tpt_invalid_probabilities():
     """Raise error if p_sterilization + p_suppression > 1."""
     with pytest.raises(ValueError, match="must be <= 1.0"):
         tbsim.TPTTx(p_sterilization=0.6, p_suppression=0.6)
+
+
+def test_tpt_mechanism_via_pars_dict():
+    """Mechanism probabilities can be passed via pars dict."""
+    product = tbsim.TPTTx(pars={'p_sterilization': 0.7, 'p_suppression': 0.3})
+    assert np.isclose(product.pars.p_sterilization, 0.7)
+    assert np.isclose(product.pars.p_suppression, 0.3)
+
+    # Also works via constructor args (existing path)
+    product2 = tbsim.TPTTx(p_sterilization=0.7, p_suppression=0.3)
+    assert np.isclose(product2.pars.p_sterilization, 0.7)


### PR DESCRIPTION
TPTTx now supports two mutually exclusive mechanisms assigned via a CRN-safe multinomial draw (ss.choice):

- Sterilization: clears latent infection (INFECTION → CLEARED) at treatment completion, using the same pattern as TxDelivery
- Suppression: reduces progression risk via rr_* modifiers during a post-treatment protection window (existing behavior)
- Neither: no benefit (e.g., non-adherent agents)

New constructor args p_sterilization (default 0.0) and p_suppression (default 1.0) preserve full backward compatibility.