### PR TITLE
Upgrade to Starsim 3.4.0 and bump TBsim to v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the codebase are documented in this file.
 
 ## Version 0.8.2 (2026-06-29)
-- Updated for Starsim 3.4.0: `HouseholdNet` is now imported from `starsim.library` as `ssl.networks.HouseholdNet` (replacing `ss.HouseholdNet`).
+- Updated for Starsim 3.4.0: `import starsim.library.networks as ssln` and `ssln.HouseholdNet` (replacing `ss.HouseholdNet`).
 - Raised minimum Starsim dependency to `>=3.4.0`.
 
 ## Version 0.8.1 (2026-06-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the codebase are documented in this file.
 
+## Version 0.8.2 (2026-06-29)
+- Updated for Starsim 3.4.0: `HouseholdNet` is now imported from `starsim.library` as `ssl.networks.HouseholdNet` (replacing `ss.HouseholdNet`).
+- Raised minimum Starsim dependency to `>=3.4.0`.
+
 ## Version 0.8.1 (2026-06-10)
 - Fixed a UID/position confusion bug (#425) where several interventions identified agents by running `np.where`/`np.flatnonzero` over a starsim `Arr`'s compact, alive-only `.values` view and then treating the resulting positions as UIDs. Once any agents had died (so UIDs no longer matched compact positions), this silently selected the wrong agents. Affected `HouseholdContactTracing.step`, `TPTHousehold.check_eligibility`, `TxDelivery._get_eligible`, `Migration._members_by_household_id`, and `HealthSeekingBehavior.step`. All now use native starsim filtering (`arr.auids[mask]`) so positions map back to real UIDs.
 - Added regression tests covering household contact tracing, treatment eligibility, care-seeking, and diagnostic administration after agent deaths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-TBsim is an agent-based tuberculosis (TB) model built on the [Starsim](https://github.com/starsimhub/starsim) framework. It simulates TB transmission, disease progression, and treatment outcomes in populations. Currently in alpha (v0.7.0). Python >=3.11.
+TBsim is an agent-based tuberculosis (TB) model built on the [Starsim](https://github.com/starsimhub/starsim) framework. It simulates TB transmission, disease progression, and treatment outcomes in populations. Currently in alpha (v0.8.2). Python >=3.11.
 
 ## Build & Development Commands
 
@@ -74,6 +74,6 @@ Interventions in [tbsim/interventions/](tbsim/interventions/) follow a product/d
 
 ## Key Dependencies
 
-- **starsim** (>=3.2.1) — ABM framework; disease models extend `ss.Disease`, interventions extend `ss.Intervention`
+- **starsim** (>=3.4.0) — ABM framework; disease models extend `ss.Disease`, interventions extend `ss.Intervention`; household networks via `starsim.library` (`ssl.networks.HouseholdNet`)
 - **sciris** (>=3.1.0) — Utility library used throughout (`sc.objdict`, `sc.mergedicts`, etc.)
 - **pandas** (>=2.0.0) — Used heavily in diagnostic product definitions (DataFrame-based)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,6 @@ Interventions in [tbsim/interventions/](tbsim/interventions/) follow a product/d
 
 ## Key Dependencies
 
-- **starsim** (>=3.4.0) — ABM framework; disease models extend `ss.Disease`, interventions extend `ss.Intervention`; household networks via `starsim.library` (`ssl.networks.HouseholdNet`)
+- **starsim** (>=3.4.0) — ABM framework; `import starsim.library.networks as ssln`, then `ssln.HouseholdNet`
 - **sciris** (>=3.1.0) — Utility library used throughout (`sc.objdict`, `sc.mergedicts`, etc.)
 - **pandas** (>=2.0.0) — Used heavily in diagnostic product definitions (DataFrame-based)

--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,2 +1,2 @@
-version: 0.8.0
-versiondate: '2026-06-02'
+version: 0.8.2
+versiondate: '2026-06-29'

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -74,7 +74,14 @@ Using household-based social networks:
 ```python
 import starsim as ss
 import starsim.library as ssl
+import sciris as sc
 from tbsim import TB
+
+# Synthetic DHS-style household data (hh_id + comma-separated ages per household)
+dhs_data = sc.dataframe(
+    hh_id=[0, 1, 2],
+    ages=['72, 17, 30', '37', '13, 55, 36'],
+)
 
 # Create household network and TB
 households = ssl.networks.HouseholdNet(dhs_data=dhs_data)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -73,8 +73,8 @@ Using household-based social networks:
 
 ```python
 import starsim as ss
-import starsim.library as ssl
 import sciris as sc
+import starsim.library.networks as ssln
 from tbsim import TB
 
 # Synthetic DHS-style household data (hh_id + comma-separated ages per household)
@@ -84,7 +84,7 @@ dhs_data = sc.dataframe(
 )
 
 # Create household network and TB (static households; no Pregnancy module required)
-households = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+households = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 tb = TB()
 
 sim = ss.Sim(

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -72,12 +72,12 @@ sim.run()
 Using household-based social networks:
 
 ```python
-from tbsim.networks import HouseholdNet
-from tbsim import TB
 import starsim as ss
+import starsim.library as ssl
+from tbsim import TB
 
 # Create household network and TB
-households = HouseholdNet()
+households = ssl.networks.HouseholdNet(dhs_data=dhs_data)
 tb = TB()
 
 sim = ss.Sim(

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -83,8 +83,8 @@ dhs_data = sc.dataframe(
     ages=['72, 17, 30', '37', '13, 55, 36'],
 )
 
-# Create household network and TB
-households = ssl.networks.HouseholdNet(dhs_data=dhs_data)
+# Create household network and TB (static households; no Pregnancy module required)
+households = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 tb = TB()
 
 sim = ss.Sim(
@@ -108,9 +108,9 @@ sim = ss.Sim(diseases=[TB()], analyzers=DwellTime(scenario_name="Baseline"))
 sim.run()
 
 # Create plots from the analyzer
-sim.analyzers[0].plot('sankey')
 sim.analyzers[0].plot('histogram')
 sim.analyzers[0].plot('kaplan_meier')
+sim.analyzers[0].plot('network')
 ```
 
 ## Parameter Sweeps

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,13 +28,23 @@ cd tbsim
 pip install -e .[dev]
 ```
 
+## Starsim library imports
+
+TBsim requires Starsim >=3.4.0. Household networks live in the Starsim library (not core ``starsim``):
+
+```python
+import starsim.library.networks as ssln
+
+net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+```
+
 ## Troubleshooting
 
 Common installation issues:
 
 **Import Errors**: Ensure you're using the correct Python environment and that all dependencies are installed.
 
-**Starsim Compatibility**: TBsim requires Starsim >=3.4.0. Install with `pip install "starsim>=3.4.0"` or let `pip install -e .` pull it in as a dependency. Household networks use `import starsim.library as ssl` and `ssl.networks.HouseholdNet`.
+**Starsim Compatibility**: Requires Starsim >=3.4.0 (`pip install "starsim>=3.4.0"`). See [Starsim library imports](#starsim-library-imports) above.
 
 **Permission Errors**: On some systems, you may need to use `pip install --user` or run with appropriate permissions.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,7 +34,7 @@ Common installation issues:
 
 **Import Errors**: Ensure you're using the correct Python environment and that all dependencies are installed.
 
-**Starsim Compatibility**: TBsim requires Starsim >=3.4.0. Install with `pip install 'starsim>=3.4.0'` or let `pip install -e .` pull it in as a dependency. Household networks use `import starsim.library as ssl` and `ssl.networks.HouseholdNet`.
+**Starsim Compatibility**: TBsim requires Starsim >=3.4.0. Install with `pip install "starsim>=3.4.0"` or let `pip install -e .` pull it in as a dependency. Household networks use `import starsim.library as ssl` and `ssl.networks.HouseholdNet`.
 
 **Permission Errors**: On some systems, you may need to use `pip install --user` or run with appropriate permissions.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,7 +34,7 @@ Common installation issues:
 
 **Import Errors**: Ensure you're using the correct Python environment and that all dependencies are installed.
 
-**Starsim Compatibility**: Make sure you have a compatible version of Starsim installed.
+**Starsim Compatibility**: TBsim requires Starsim >=3.4.0. Install with `pip install 'starsim>=3.4.0'` or let `pip install -e .` pull it in as a dependency. Household networks use `import starsim.library as ssl` and `ssl.networks.HouseholdNet`.
 
 **Permission Errors**: On some systems, you may need to use `pip install --user` or run with appropriate permissions.
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -174,8 +174,8 @@ Basic simulation workflow:
 
 ```python
 import starsim as ss
-import starsim.library as ssl
 import sciris as sc
+import starsim.library.networks as ssln
 import tbsim
 
 # Synthetic DHS-style household data (hh_id + comma-separated ages per household)
@@ -187,7 +187,7 @@ dhs_data = sc.dataframe(
 # Create simulation with TB model and analyzer
 sim = ss.Sim(
     diseases=[tbsim.TB()],
-    networks=ssl.networks.HouseholdNet(dhs_data=dhs_data),
+    networks=ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False),
     analyzers=[tbsim.DwellTime(scenario_name="Baseline")]
 )
 sim.run()

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -175,7 +175,14 @@ Basic simulation workflow:
 ```python
 import starsim as ss
 import starsim.library as ssl
+import sciris as sc
 import tbsim
+
+# Synthetic DHS-style household data (hh_id + comma-separated ages per household)
+dhs_data = sc.dataframe(
+    hh_id=[0, 1, 2],
+    ages=['72, 17, 30', '37', '13, 55, 36'],
+)
 
 # Create simulation with TB model and analyzer
 sim = ss.Sim(

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -174,12 +174,13 @@ Basic simulation workflow:
 
 ```python
 import starsim as ss
+import starsim.library as ssl
 import tbsim
 
 # Create simulation with TB model and analyzer
 sim = ss.Sim(
     diseases=[tbsim.TB()],
-    networks=tbsim.HouseholdNet(),
+    networks=ssl.networks.HouseholdNet(dhs_data=dhs_data),
     analyzers=[tbsim.DwellTime(scenario_name="Baseline")]
 )
 sim.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "networkx",
   "matplotlib",
   "seaborn",
-  "starsim>=3.2.1",
+  "starsim>=3.4.0",
 ]
 
 [project.optional-dependencies]

--- a/tbsim/analyzers.py
+++ b/tbsim/analyzers.py
@@ -552,7 +552,7 @@ class HouseholdStats(ss.Analyzer):
     Track household size, age, and contact-mixing statistics over time.
 
     Works with any network that exposes a ``household_ids`` state (e.g.
-    ``starsim.HouseholdNet``).  At each timestep the
+    ``ssl.networks.HouseholdNet``).  At each timestep the
     analyzer counts alive agents per household and records summary statistics.
 
     Args:
@@ -579,11 +579,11 @@ class HouseholdStats(ss.Analyzer):
     Example::
 
         import starsim as ss
-        import starsim_examples as sse
+        import starsim.library as ssl
         import tbsim
 
         dhs_data = ...  # pandas DataFrame with hh_id and ages columns
-        net = ss.HouseholdNet(dhs_data=dhs_data)
+        net = ssl.networks.HouseholdNet(dhs_data=dhs_data)
         analyzer = tbsim.HouseholdStats(network_name='householdnet')
         sim = ss.Sim(
             diseases='sis', networks=net,

--- a/tbsim/analyzers.py
+++ b/tbsim/analyzers.py
@@ -552,7 +552,7 @@ class HouseholdStats(ss.Analyzer):
     Track household size, age, and contact-mixing statistics over time.
 
     Works with any network that exposes a ``household_ids`` state (e.g.
-    ``ssl.networks.HouseholdNet``).  At each timestep the
+    ``starsim.library.networks.HouseholdNet``).  At each timestep the
     analyzer counts alive agents per household and records summary statistics.
 
     Args:
@@ -579,11 +579,11 @@ class HouseholdStats(ss.Analyzer):
     Example::
 
         import starsim as ss
-        import starsim.library as ssl
+        import starsim.library.networks as ssln
         import tbsim
 
         dhs_data = ...  # pandas DataFrame with hh_id and ages columns
-        net = ssl.networks.HouseholdNet(dhs_data=dhs_data)
+        net = ssln.HouseholdNet(dhs_data=dhs_data)
         analyzer = tbsim.HouseholdStats(network_name='householdnet')
         sim = ss.Sim(
             diseases='sis', networks=net,

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -263,7 +263,7 @@ class TPTHousehold(TBProductRoutine):
     handles eligibility filtering).
 
     Requires a household network with ``household_ids`` (e.g.
-    ``ssl.networks.HouseholdNet``).
+    ``starsim.library.networks.HouseholdNet``).
 
     Args:
         product (TPTTx): The TPT treatment product (created automatically if not provided).
@@ -358,7 +358,7 @@ class HouseholdContactTracing(ss.Intervention):
     index cases. Downstream interventions (e.g. ``DxDelivery`` for screening,
     ``TPTDelivery`` for preventive therapy) read this flag.
 
-    Requires a household network with ``household_ids`` (e.g. ``ssl.networks.HouseholdNet``).
+    Requires a household network with ``household_ids`` (e.g. ``starsim.library.networks.HouseholdNet``).
 
     Args:
         coverage (float): Probability that a given index case's household is

--- a/tbsim/interventions/tpt.py
+++ b/tbsim/interventions/tpt.py
@@ -263,7 +263,7 @@ class TPTHousehold(TBProductRoutine):
     handles eligibility filtering).
 
     Requires a household network with ``household_ids`` (e.g.
-    ``ss.HouseholdNet``).
+    ``ssl.networks.HouseholdNet``).
 
     Args:
         product (TPTTx): The TPT treatment product (created automatically if not provided).
@@ -358,7 +358,7 @@ class HouseholdContactTracing(ss.Intervention):
     index cases. Downstream interventions (e.g. ``DxDelivery`` for screening,
     ``TPTDelivery`` for preventive therapy) read this flag.
 
-    Requires a household network with ``household_ids`` (e.g. ``ss.HouseholdNet``).
+    Requires a household network with ``household_ids`` (e.g. ``ssl.networks.HouseholdNet``).
 
     Args:
         coverage (float): Probability that a given index case's household is

--- a/tbsim/migration.py
+++ b/tbsim/migration.py
@@ -16,7 +16,7 @@ class Migration(ss.Demographics):
     emigration (existing agents leaving). Each timestep, arrivals are drawn
     from a Poisson process and departures are sampled from the active
     population. Immigrants are assigned an age, a TB disease state, and
-    (when a ``ssl.networks.HouseholdNet`` is present) a household. Emigrants are removed
+    (when ``starsim.library.networks.HouseholdNet`` is present) a household. Emigrants are removed
     from the disease model and from household networks. Setting
     ``emigration_rate=0`` gives an immigration-only module.
 
@@ -72,7 +72,7 @@ class Migration(ss.Demographics):
         n_emigrants: Number of departures in the last step.
         net_migration: ``n_immigrants - n_emigrants`` for the last step.
 
-    **Household integration**: When a ``ssl.networks.HouseholdNet`` is present in the sim,
+    **Household integration**: When ``starsim.library.networks.HouseholdNet`` is present in the sim,
     immigrants are added to existing households (weighted by household size)
     and connected via complete-graph edges. Emigrants are removed from their
     household membership and edges.

--- a/tbsim/migration.py
+++ b/tbsim/migration.py
@@ -16,7 +16,7 @@ class Migration(ss.Demographics):
     emigration (existing agents leaving). Each timestep, arrivals are drawn
     from a Poisson process and departures are sampled from the active
     population. Immigrants are assigned an age, a TB disease state, and
-    (when a ``HouseholdNet`` is present) a household. Emigrants are removed
+    (when a ``ssl.networks.HouseholdNet`` is present) a household. Emigrants are removed
     from the disease model and from household networks. Setting
     ``emigration_rate=0`` gives an immigration-only module.
 
@@ -72,7 +72,7 @@ class Migration(ss.Demographics):
         n_emigrants: Number of departures in the last step.
         net_migration: ``n_immigrants - n_emigrants`` for the last step.
 
-    **Household integration**: When a ``HouseholdNet`` is present in the sim,
+    **Household integration**: When a ``ssl.networks.HouseholdNet`` is present in the sim,
     immigrants are added to existing households (weighted by household size)
     and connected via complete-graph edges. Emigrants are removed from their
     household membership and edges.

--- a/tbsim/version.py
+++ b/tbsim/version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__ = '0.8.1'
-__versiondate__ = '2026-06-10'
+__version__ = '0.8.2'
+__versiondate__ = '2026-06-29'
 __license__ = f'TBsim {__version__} ({__versiondate__}) — © 2023-2026 by IDM'

--- a/tbsim_examples/archive/run_dhs_household.py
+++ b/tbsim_examples/archive/run_dhs_household.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import sciris as sc
 import starsim as ss
-import starsim.library as ssl
+import starsim.library.networks as ssln
 import tbsim
 
 raise NotImplementedError('Awaiting more permanent data solution')
@@ -44,7 +44,7 @@ dhs_data = sc.dataframe(hh_id=hh_ids, ages=age_strings)
 n_agents = sum(len(s.split()) for s in age_strings)  # make this match the HH structure
 
 # -- 2. Build simulation components -------------------------------------------
-net = ssl.networks.HouseholdNet(dhs_data=dhs_data, prob_move_out=0.7)
+net = ssln.HouseholdNet(dhs_data=dhs_data, prob_move_out=0.7)
 
 fertility_rates = pd.read_csv(Path(__file__).parents[1] / "tbsim" / "data" / "nigeria_asfr.csv")
 pregnancy = ss.Pregnancy(fertility_rate=fertility_rates)

--- a/tbsim_examples/archive/run_dhs_household.py
+++ b/tbsim_examples/archive/run_dhs_household.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import sciris as sc
 import starsim as ss
+import starsim.library as ssl
 import tbsim
 
 raise NotImplementedError('Awaiting more permanent data solution')
@@ -43,7 +44,7 @@ dhs_data = sc.dataframe(hh_id=hh_ids, ages=age_strings)
 n_agents = sum(len(s.split()) for s in age_strings)  # make this match the HH structure
 
 # -- 2. Build simulation components -------------------------------------------
-net = ss.HouseholdNet(dhs_data=dhs_data, prob_move_out=0.7)
+net = ssl.networks.HouseholdNet(dhs_data=dhs_data, prob_move_out=0.7)
 
 fertility_rates = pd.read_csv(Path(__file__).parents[1] / "tbsim" / "data" / "nigeria_asfr.csv")
 pregnancy = ss.Pregnancy(fertility_rate=fertility_rates)

--- a/tbsim_examples/run_migration.py
+++ b/tbsim_examples/run_migration.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import sciris as sc
 import starsim as ss
-import starsim.library as ssl
+import starsim.library.networks as ssln
 import tbsim
 
 
@@ -34,7 +34,7 @@ DEFAULT_MIGRATION_PARS = dict(
 
 
 def _make_household_dhs_data(n_agents, rand_seed):
-    """Create a synthetic DHS household table for ``ssl.networks.HouseholdNet``."""
+    """Create a synthetic DHS household table for ``starsim.library.networks.HouseholdNet``."""
     rng = np.random.default_rng(rand_seed)
     hh_id = []
     ages = []
@@ -70,7 +70,7 @@ def build_sim(scenario=None, spars=None):
     include_households = bool(scenario.get('use_households', True))
     networks = [ss.RandomNet(pars=dict(n_contacts=ss.poisson(lam=5), dur=0))]
     if include_households:
-        networks.append(ssl.networks.HouseholdNet(dhs_data=_make_household_dhs_data(n_agents=spars.n_agents, rand_seed=spars.rand_seed), dynamic=False))
+        networks.append(ssln.HouseholdNet(dhs_data=_make_household_dhs_data(n_agents=spars.n_agents, rand_seed=spars.rand_seed), dynamic=False))
 
     return tbsim.Sim(
         label=scenario.get('name', 'scenario'),

--- a/tbsim_examples/run_migration.py
+++ b/tbsim_examples/run_migration.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import sciris as sc
 import starsim as ss
+import starsim.library as ssl
 import tbsim
 
 
@@ -33,7 +34,7 @@ DEFAULT_MIGRATION_PARS = dict(
 
 
 def _make_household_dhs_data(n_agents, rand_seed):
-    """Create a synthetic DHS household table for ``ss.HouseholdNet``."""
+    """Create a synthetic DHS household table for ``ssl.networks.HouseholdNet``."""
     rng = np.random.default_rng(rand_seed)
     hh_id = []
     ages = []
@@ -69,7 +70,7 @@ def build_sim(scenario=None, spars=None):
     include_households = bool(scenario.get('use_households', True))
     networks = [ss.RandomNet(pars=dict(n_contacts=ss.poisson(lam=5), dur=0))]
     if include_households:
-        networks.append(ss.HouseholdNet(dhs_data=_make_household_dhs_data(n_agents=spars.n_agents, rand_seed=spars.rand_seed), dynamic=False))
+        networks.append(ssl.networks.HouseholdNet(dhs_data=_make_household_dhs_data(n_agents=spars.n_agents, rand_seed=spars.rand_seed), dynamic=False))
 
     return tbsim.Sim(
         label=scenario.get('name', 'scenario'),

--- a/tbsim_examples/run_tb_interventions.py
+++ b/tbsim_examples/run_tb_interventions.py
@@ -5,7 +5,7 @@ TB interventions example: scenarios with BCG, TPT, BetaByYear, and Dx/Tx cascade
 import numpy as np
 import sciris as sc
 import starsim as ss
-import starsim.library as ssl
+import starsim.library.networks as ssln
 import tbsim
 import matplotlib.pyplot as plt
 
@@ -90,7 +90,7 @@ def build_sim(scenario=None, spars=None):
     dhs_data = sc.dataframe(hh_id=np.arange(n_households), ages=age_strings)
     networks = [
         ss.RandomNet({'n_contacts': ss.poisson(lam=5), 'dur': 0}),
-        ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False),
+        ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False),
     ]
 
     spars.n_agents = 500
@@ -227,7 +227,7 @@ def run_tpt_cascade():
     dhs_data = sc.dataframe(hh_id=hh_ids, ages=age_strings)
 
     # Networks
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
     community_net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=3), dur=0))
 
     # --- Index case pathway ---

--- a/tbsim_examples/run_tb_interventions.py
+++ b/tbsim_examples/run_tb_interventions.py
@@ -5,6 +5,7 @@ TB interventions example: scenarios with BCG, TPT, BetaByYear, and Dx/Tx cascade
 import numpy as np
 import sciris as sc
 import starsim as ss
+import starsim.library as ssl
 import tbsim
 import matplotlib.pyplot as plt
 
@@ -89,7 +90,7 @@ def build_sim(scenario=None, spars=None):
     dhs_data = sc.dataframe(hh_id=np.arange(n_households), ages=age_strings)
     networks = [
         ss.RandomNet({'n_contacts': ss.poisson(lam=5), 'dur': 0}),
-        ss.HouseholdNet(dhs_data=dhs_data, dynamic=False),
+        ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False),
     ]
 
     spars.n_agents = 500
@@ -226,7 +227,7 @@ def run_tpt_cascade():
     dhs_data = sc.dataframe(hh_id=hh_ids, ages=age_strings)
 
     # Networks
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
     community_net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=3), dur=0))
 
     # --- Index case pathway ---

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -5,7 +5,7 @@ Test TBsim analyzers
 import numpy as np
 import sciris as sc
 import starsim as ss
-import starsim.library as ssl
+import starsim.library.networks as ssln
 import tbsim
 import pytest
 
@@ -29,7 +29,7 @@ def test_householdstats():
     hh_ids = np.arange(50)
     ages = [sc.strjoin(np.random.randint(1, 70, np.random.randint(2, 6))) for _ in hh_ids]
     dhs = sc.dataframe(hh_id=hh_ids, ages=ages)
-    net = ssl.networks.HouseholdNet(dhs_data=dhs, dynamic=False)
+    net = ssln.HouseholdNet(dhs_data=dhs, dynamic=False)
     az = tbsim.HouseholdStats(save_at=['2001-01-01', '2004-01-01'])
     sim = make_sim(analyzers=az, networks=net, copy_inputs=False)
     sim.run()

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -5,6 +5,7 @@ Test TBsim analyzers
 import numpy as np
 import sciris as sc
 import starsim as ss
+import starsim.library as ssl
 import tbsim
 import pytest
 
@@ -28,7 +29,7 @@ def test_householdstats():
     hh_ids = np.arange(50)
     ages = [sc.strjoin(np.random.randint(1, 70, np.random.randint(2, 6))) for _ in hh_ids]
     dhs = sc.dataframe(hh_id=hh_ids, ages=ages)
-    net = ss.HouseholdNet(dhs_data=dhs, dynamic=False)
+    net = ssl.networks.HouseholdNet(dhs_data=dhs, dynamic=False)
     az = tbsim.HouseholdStats(save_at=['2001-01-01', '2004-01-01'])
     sim = make_sim(analyzers=az, networks=net, copy_inputs=False)
     sim.run()

--- a/tests/test_examples_md.py
+++ b/tests/test_examples_md.py
@@ -1,0 +1,75 @@
+"""Smoke-test runnable code blocks from docs/examples.md."""
+
+import matplotlib
+matplotlib.use('Agg')
+
+import numpy as np
+import pytest
+import sciris as sc
+import starsim as ss
+import starsim.library as ssl
+import tbsim
+from tbsim import TB
+from tbsim.analyzers import DwellTime
+from tbsim.comorbidities.hiv import HIV
+
+
+def test_example_basic_tb_simulation():
+    sim = ss.Sim(diseases=TB())
+    sim.run()
+    sim.plot()
+
+
+def test_example_tb_with_interventions():
+    tb = TB()
+    bcg = tbsim.BCGRoutine(pars=dict(
+        coverage=ss.bernoulli(p=0.8),
+        start=ss.date('1980-01-01'),
+        stop=ss.date('2030-12-31'),
+        age_range=[0, 5],
+    ))
+    tpt = tbsim.TPTSimple(pars=dict(
+        start=ss.date('1990-01-01'),
+        stop=ss.date('2030-12-31'),
+    ))
+    sim = ss.Sim(
+        diseases=tb,
+        interventions=[bcg, tpt],
+        pars=dict(start=ss.date('1975-01-01'), stop=ss.date('2030-12-31')),
+    )
+    sim.run()
+
+
+def test_example_tb_hiv_comorbidity():
+    sim = ss.Sim(diseases=[TB(), HIV()])
+    sim.run()
+
+
+def test_example_household_networks():
+    dhs_data = sc.dataframe(
+        hh_id=[0, 1, 2],
+        ages=['72, 17, 30', '37', '13, 55, 36'],
+    )
+    sim = ss.Sim(
+        networks=ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False),
+        diseases=TB(),
+    )
+    sim.run()
+
+
+def test_example_advanced_analysis():
+    sim = ss.Sim(diseases=[TB()], analyzers=DwellTime(scenario_name="Baseline"))
+    sim.run()
+    az = sim.analyzers[0]
+    az.plot('histogram')
+    az.plot('kaplan_meier')
+    az.plot('network')
+
+
+def test_example_parameter_sweeps():
+    results = []
+    for rate in np.linspace(0.1, 0.5, 5):
+        sim = ss.Sim(diseases=TB(pars={'beta': ss.peryear(rate)}))
+        sim.run()
+        results.append(sim.results)
+    assert len(results) == 5

--- a/tests/test_examples_md.py
+++ b/tests/test_examples_md.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import sciris as sc
 import starsim as ss
-import starsim.library as ssl
+import starsim.library.networks as ssln
 import tbsim
 from tbsim import TB
 from tbsim.analyzers import DwellTime
@@ -51,7 +51,7 @@ def test_example_household_networks():
         ages=['72, 17, 30', '37', '13, 55, 36'],
     )
     sim = ss.Sim(
-        networks=ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False),
+        networks=ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False),
         diseases=TB(),
     )
     sim.run()

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import sciris as sc
 import starsim as ss
-import starsim.library as ssl
+import starsim.library.networks as ssln
 import tbsim
 
 
@@ -248,7 +248,7 @@ def test_tpt_product_skips_on_treatment():
 def test_tpt_household_init():
     """Test TPTHousehold initializes with correct defaults."""
     dhs_data = make_dhs_data(50)
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     tpt_hh = tbsim.TPTHousehold()
@@ -268,7 +268,7 @@ def test_tpt_household_init():
 def test_tpt_household_traces_on_treatment_start():
     """Test that household contacts are offered TPT when an index starts treatment."""
     dhs_data = make_dhs_data(50)
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     tpt_hh = tbsim.TPTHousehold(pars={'coverage': 1.0})
@@ -302,7 +302,7 @@ def test_tpt_household_traces_on_treatment_start():
 def test_tpt_household_no_retrigger_same_index():
     """Test that the same index case doesn't retrigger tracing on subsequent steps."""
     dhs_data = make_dhs_data(50)
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     tpt_hh = tbsim.TPTHousehold(pars={'coverage': 1.0})
@@ -331,7 +331,7 @@ def test_tpt_household_no_retrigger_same_index():
 def test_tpt_household_full_sim_run():
     """Test that TPTHousehold runs without error in a full simulation."""
     dhs_data = make_dhs_data(30)
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20, 'beta': ss.peryear(0.5)})
     tpt_hh = tbsim.TPTHousehold(pars={'coverage': 0.8})
@@ -357,7 +357,7 @@ def test_tpt_household_full_sim_run():
 def test_hh_contact_tracing_identifies_contacts():
     """HouseholdContactTracing sets contact_identified on household members."""
     dhs_data = make_dhs_data(50)
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
@@ -397,7 +397,7 @@ def test_hh_contact_tracing_correct_after_deaths():
     """
     np.random.seed(0)
     dhs_data = make_dhs_data(60)
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.0})
     hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
@@ -452,7 +452,7 @@ def test_hh_contact_tracing_correct_after_deaths():
 def test_hh_contact_tracing_no_retrigger():
     """Same index case does not retrigger contact identification."""
     dhs_data = make_dhs_data(50)
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
@@ -483,7 +483,7 @@ def test_hh_contact_tracing_no_retrigger():
 def _make_cascade_sim(n_agents=500, n_households=100, rand_seed=42):
     """Build a full TPT cascade sim for testing."""
     dhs_data = make_dhs_data(n_households)
-    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssln.HouseholdNet(dhs_data=dhs_data, dynamic=False)
     community_net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=3), dur=0))
 
     hsb = tbsim.HealthSeekingBehavior()

--- a/tests/test_tpt.py
+++ b/tests/test_tpt.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import sciris as sc
 import starsim as ss
+import starsim.library as ssl
 import tbsim
 
 
@@ -247,7 +248,7 @@ def test_tpt_product_skips_on_treatment():
 def test_tpt_household_init():
     """Test TPTHousehold initializes with correct defaults."""
     dhs_data = make_dhs_data(50)
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     tpt_hh = tbsim.TPTHousehold()
@@ -267,7 +268,7 @@ def test_tpt_household_init():
 def test_tpt_household_traces_on_treatment_start():
     """Test that household contacts are offered TPT when an index starts treatment."""
     dhs_data = make_dhs_data(50)
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     tpt_hh = tbsim.TPTHousehold(pars={'coverage': 1.0})
@@ -301,7 +302,7 @@ def test_tpt_household_traces_on_treatment_start():
 def test_tpt_household_no_retrigger_same_index():
     """Test that the same index case doesn't retrigger tracing on subsequent steps."""
     dhs_data = make_dhs_data(50)
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     tpt_hh = tbsim.TPTHousehold(pars={'coverage': 1.0})
@@ -330,7 +331,7 @@ def test_tpt_household_no_retrigger_same_index():
 def test_tpt_household_full_sim_run():
     """Test that TPTHousehold runs without error in a full simulation."""
     dhs_data = make_dhs_data(30)
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20, 'beta': ss.peryear(0.5)})
     tpt_hh = tbsim.TPTHousehold(pars={'coverage': 0.8})
@@ -356,7 +357,7 @@ def test_tpt_household_full_sim_run():
 def test_hh_contact_tracing_identifies_contacts():
     """HouseholdContactTracing sets contact_identified on household members."""
     dhs_data = make_dhs_data(50)
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
@@ -396,7 +397,7 @@ def test_hh_contact_tracing_correct_after_deaths():
     """
     np.random.seed(0)
     dhs_data = make_dhs_data(60)
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.0})
     hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
@@ -451,7 +452,7 @@ def test_hh_contact_tracing_correct_after_deaths():
 def test_hh_contact_tracing_no_retrigger():
     """Same index case does not retrigger contact identification."""
     dhs_data = make_dhs_data(50)
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
 
     tb = tbsim.TB(name='tb', pars={'init_prev': 0.20})
     hh_tracing = tbsim.HouseholdContactTracing(coverage=1.0)
@@ -482,7 +483,7 @@ def test_hh_contact_tracing_no_retrigger():
 def _make_cascade_sim(n_agents=500, n_households=100, rand_seed=42):
     """Build a full TPT cascade sim for testing."""
     dhs_data = make_dhs_data(n_households)
-    hh_net = ss.HouseholdNet(dhs_data=dhs_data, dynamic=False)
+    hh_net = ssl.networks.HouseholdNet(dhs_data=dhs_data, dynamic=False)
     community_net = ss.RandomNet(dict(n_contacts=ss.poisson(lam=3), dur=0))
 
     hsb = tbsim.HealthSeekingBehavior()


### PR DESCRIPTION
## Summary
- Migrates `HouseholdNet` usage from `ss.HouseholdNet` to `ssl.networks.HouseholdNet` (`import starsim.library as ssl`) to match Starsim 3.4.0's library reorganization.
- Raises the minimum Starsim dependency from `>=3.2.1` to `>=3.4.0` in `pyproject.toml`.
- Bumps TBsim to **v0.8.2** with changelog, docs version stamp, and installation guidance updates.

## Test plan
- [x] `pytest tests/test_analyzers.py::test_householdstats` passes with Starsim 3.4.0
- [x] `pytest tests/test_tpt.py -k household` passes with Starsim 3.4.0
- [x] Full test suite passes (`125 passed`) with Starsim 3.4.0
- [ ] CI green on merge to `main`


BTW - @cliffckerr  I am not particullarly fan of using the long name "ssl.networks.HouseholdNet" - just wanted to flag it to make sure this is not set in stone.

Made with [Cursor](https://cursor.com)