### PR TITLE
Notes on 439

### DIFF
--- a/tbsim/resistance/codex_review/high_gap_scripts/high_gap_01_dst_default_retreatment.py
+++ b/tbsim/resistance/codex_review/high_gap_scripts/high_gap_01_dst_default_retreatment.py
@@ -1,0 +1,148 @@
+"""
+High Gap 01: Default DST-linked retreatment still targets CLEARED agents.
+
+Purpose
+- Reproduce the high-severity issue where DST-routed treatment eligibility can
+  repeatedly select agents who are already CLEARED.
+- Show the default behavior and an optional guarded behavior side by side.
+
+How to run
+- From repo root:
+  /Users/mine/git/tbsimFINAL/venv/bin/python \
+    tbsim/resistance/codex_review/high_gap_scripts/high_gap_01_dst_default_retreatment.py
+
+What this script prints
+- CLEARED selection fraction under default settings.
+- CLEARED selection fraction with optional safeguards enabled
+  (result_validity + retreat_after).
+- A brief interpretation block for quick sharing.
+"""
+
+from collections import Counter
+
+import starsim as ss
+import tbsim
+from tbsim.tb import TBS
+
+
+def run_scenario(use_guards=False):
+    """Run one DST-routed scenario and return a state-count summary of selected starts."""
+    log = {"states": []}
+    original_initiate = tbsim.TxDeliveryR._initiate
+
+    def probed_initiate(self):
+        tb = tbsim.get_tb(self.sim, which=tbsim.TBResistant)
+
+        # SECTION A: Record the states selected by eligibility for this step.
+        if self.eligibility is not None:
+            selected = ss.uids(self.eligibility(self.sim))
+            selected = selected[tb.state[selected] != TBS.TREATMENT]
+            log["states"].extend(int(tb.state[u]) for u in selected)
+
+        return original_initiate(self)
+
+    tbsim.TxDeliveryR._initiate = probed_initiate
+
+    try:
+        # SECTION B: Build disease, DST, and two DST-routed treatment lines.
+        tb = tbsim.TBResistant(
+            drugs=["RIF"],
+            rel_fitness={"RIF": 0.9},
+            pars=dict(
+                beta=ss.permonth(0.35),
+                init_prev=ss.bernoulli(0.12),
+                init_strains=[0.8, 0.2],
+                rr_reinfection_inf=1.0,
+                rr_reinfection_non=1.0,
+            ),
+        )
+
+        dst_kwargs = {}
+        first_kwargs = {}
+        second_kwargs = {}
+        if use_guards:
+            # Optional mitigation knobs available on this branch.
+            dst_kwargs["result_validity"] = ss.months(1)
+            first_kwargs["retreat_after"] = ss.months(1)
+            second_kwargs["retreat_after"] = ss.months(1)
+
+        dst = tbsim.DSTDelivery(
+            name="dst",
+            product=tbsim.DST(strains=tb.strains, sens=0.95, spec=0.98),
+            eligibility=lambda sim: tbsim.get_tb(sim, which=tbsim.TBResistant).active_tb.uids,
+            **dst_kwargs,
+        )
+
+        first = tbsim.TxDeliveryR(
+            name="first",
+            eligibility=dst.matches(RIF=False),
+            product=tbsim.TxR(strains=tb.strains, base_efficacy=0.85, resist_penalty={"RIF": 0.1}),
+            **first_kwargs,
+        )
+
+        second = tbsim.TxDeliveryR(
+            name="second",
+            eligibility=dst.matches(RIF=True),
+            product=tbsim.TxR(strains=tb.strains, base_efficacy=0.8, regimen_drugs=["RIF"]),
+            **second_kwargs,
+        )
+
+        net = ss.RandomNet(pars=dict(n_contacts=ss.poisson(lam=8), dur=0))
+
+        # SECTION C: Run long horizon to expose repeated-selection behavior.
+        sim = ss.Sim(
+            n_agents=2000,
+            networks=net,
+            diseases=tb,
+            interventions=[dst, first, second],
+            dt=ss.days(30),
+            start=ss.date("2000-01-01"),
+            stop=ss.date("2030-12-31"),
+            rand_seed=0,
+            verbose=0,
+        )
+        sim.run()
+
+        counts = Counter(log["states"])
+        total = sum(counts.values())
+        cleared = counts.get(int(TBS.CLEARED), 0)
+        frac_cleared = 0.0 if total == 0 else cleared / total
+
+        return {
+            "counts_by_state": {TBS(k).name: v for k, v in sorted(counts.items())},
+            "total_selected": total,
+            "cleared_selected": cleared,
+            "cleared_fraction": frac_cleared,
+        }
+    finally:
+        tbsim.TxDeliveryR._initiate = original_initiate
+
+
+def main():
+    print("=== High Gap 01: DST-linked retreatment behavior ===")
+
+    # SECTION D1: Default behavior on this branch.
+    default = run_scenario(use_guards=False)
+    print("\n[Default configuration]")
+    print(f"Selected counts by state: {default['counts_by_state']}")
+    print(f"Total selected starts: {default['total_selected']}")
+    print(f"Selected CLEARED starts: {default['cleared_selected']}")
+    print(f"CLEARED selection fraction: {default['cleared_fraction']:.4f}")
+
+    # SECTION D2: Optional guarded behavior for comparison.
+    guarded = run_scenario(use_guards=True)
+    print("\n[Optional guarded configuration]")
+    print(f"Selected counts by state: {guarded['counts_by_state']}")
+    print(f"Total selected starts: {guarded['total_selected']}")
+    print(f"Selected CLEARED starts: {guarded['cleared_selected']}")
+    print(f"CLEARED selection fraction: {guarded['cleared_fraction']:.4f}")
+
+    # SECTION E: High-level interpretation for quick sharing.
+    print("\n[Interpretation]")
+    print("- If default CLEARED fraction is high, the DST retreatment gap is present.")
+    print("- If default CLEARED fraction is near zero, the default behavior is protected.")
+    print("- Guarded configuration demonstrates behavior with explicit freshness/retreatment controls.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tbsim/resistance/codex_review/high_gap_scripts/high_gap_02_latent_treatment_divergence.py
+++ b/tbsim/resistance/codex_review/high_gap_scripts/high_gap_02_latent_treatment_divergence.py
@@ -1,0 +1,92 @@
+"""
+High Gap 02: Latent treatment divergence in TxDeliveryR behavior modes.
+
+Purpose
+- Demonstrate how latent-agent handling differs between treat_latent=False and
+  treat_latent=True in resistance treatment delivery.
+- Provide an easy, shareable script that prints mode-specific outcomes.
+
+How to run
+- From repo root:
+  /Users/mine/git/tbsimFINAL/venv/bin/python \
+    tbsim/resistance/codex_review/high_gap_scripts/high_gap_02_latent_treatment_divergence.py
+
+What this script prints
+- For each mode, total treated and total successful courses.
+- End-of-run latent count.
+- A concise interpretation to share with another developer.
+"""
+
+import starsim as ss
+import tbsim
+from tbsim.tb import TBS, get_tb
+
+
+def run_mode(treat_latent):
+    """Run one latent-targeted treatment scenario for a chosen treat_latent mode."""
+
+    # SECTION A: Build a resistant TB model with no transmission to isolate treatment behavior.
+    tb = tbsim.TBResistant(
+        drugs=["TX"],
+        rel_fitness={"TX": 0.9},
+        pars=dict(beta=ss.permonth(0.0), init_prev=ss.bernoulli(0.5), init_strains=[0.5, 0.5]),
+    )
+
+    # SECTION B: Target latent agents directly via custom eligibility.
+    tx = tbsim.TxDeliveryR(
+        name="tx",
+        eligibility=lambda sim: get_tb(sim, which=tbsim.TBResistant).latent.uids,
+        product=tbsim.TxR(strains=tb.strains, base_efficacy=0.0, adherence=1.0),
+        treat_latent=treat_latent,
+    )
+
+    # SECTION C: Run and collect outputs.
+    net = ss.RandomNet(pars=dict(n_contacts=ss.poisson(lam=1), dur=0))
+    sim = ss.Sim(
+        n_agents=2000,
+        networks=net,
+        diseases=tb,
+        interventions=[tx],
+        dt=ss.days(30),
+        start=ss.date("2000-01-01"),
+        stop=ss.date("2001-06-30"),
+        rand_seed=0,
+        verbose=0,
+    )
+    sim.run()
+
+    tb_live = sim.diseases["tb"]
+    results = sim.results["tx"]
+
+    return {
+        "treated_total": int(results.n_treated.sum()),
+        "success_total": int(results.n_success.sum()),
+        "latent_end": int((tb_live.state == TBS.INFECTION).count()),
+    }
+
+
+def main():
+    print("=== High Gap 02: Latent treatment divergence ===")
+
+    # SECTION D1: Mode that clears latent immediately (no course count).
+    mode_false = run_mode(treat_latent=False)
+    print("\n[treat_latent=False]")
+    print(f"Total treated courses: {mode_false['treated_total']}")
+    print(f"Total successful courses: {mode_false['success_total']}")
+    print(f"Latent agents at end: {mode_false['latent_end']}")
+
+    # SECTION D2: Mode that routes latent agents through full course logic.
+    mode_true = run_mode(treat_latent=True)
+    print("\n[treat_latent=True]")
+    print(f"Total treated courses: {mode_true['treated_total']}")
+    print(f"Total successful courses: {mode_true['success_total']}")
+    print(f"Latent agents at end: {mode_true['latent_end']}")
+
+    # SECTION E: High-level interpretation for quick sharing.
+    print("\n[Interpretation]")
+    print("- The two modes produce materially different bookkeeping and dynamics.")
+    print("- This demonstrates the latent-treatment behavior divergence gap.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tbsim/resistance/dst.py
+++ b/tbsim/resistance/dst.py
@@ -135,11 +135,12 @@ class DSTDelivery(ss.Intervention):
         tb = get_tb(sim, which=TBResistant)
         return (tb.active_tb & sim.people.alive & ~self.dst_tested).uids
 
-    def observed_resistant(self, drug, max_age=None):
+    def observed_resistant(self, drug, max_age=None, require_active_tb=True):
         """Return a callable ``sim -> uids`` selecting agents observed resistant to ``drug`` (for treatment eligibility).
 
         If ``max_age`` (``ss.dur``) is given, only agents whose result is within that window of the
-        current step are selected (freshness gating; L1).
+        current step are selected (freshness gating; L1). If ``require_active_tb`` is ``True``
+        (default), only currently active-TB agents are selected.
         """
         di = self.product.strains.drug_idx[drug]
         name = self.name  # resolve the sim's own (copied) DST instance at call time
@@ -150,17 +151,21 @@ class DSTDelivery(ss.Intervention):
             if max_age is not None and len(sel):
                 age = sim.ti - np.asarray(dst.ti_dst[sel], dtype=float)
                 sel = sel[age <= (max_age / dst.t.dt)]
+            if require_active_tb and len(sel):
+                tb = get_tb(sim, which=TBResistant)
+                sel = sel[tb.active_tb[sel]]
             return sel
         return _elig
 
-    def matches(self, require_tested=True, exclude_on_treatment=True, max_age=None, **per_drug):
+    def matches(self, require_tested=True, exclude_on_treatment=True, max_age=None, require_active_tb=True, **per_drug):
         """Return an eligibility callable selecting agents whose observed DST profile matches ``per_drug``.
 
         E.g. ``matches(RIF=True, BDQ=False)`` selects observed-RIF-resistant, observed-BDQ-susceptible
         agents. The returned ``sim -> uids`` callable restricts to DST-tested (unless
         ``require_tested=False``) and, unless ``exclude_on_treatment=False``, not-currently-on-treatment
-        agents. If ``max_age`` (``ss.dur``) is given, only agents whose result is within that window of
-        the current step match (freshness gating; L1). Compose with
+        agents. If ``require_active_tb`` is ``True`` (default), only currently active-TB agents match.
+        If ``max_age`` (``ss.dur``) is given, only agents whose result is within that window of the
+        current step match (freshness gating; L1). Compose with
         ``TxDeliveryR(eligibility=..., supersedes=[...])`` to route or switch regimens.
         """
         strains = self.product.strains
@@ -180,6 +185,9 @@ class DSTDelivery(ss.Intervention):
                 age = sim.ti - np.asarray(dst.ti_dst[sel], dtype=float)
                 mask &= age <= (max_age / dst.t.dt)
             out = sel[mask]
+            if require_active_tb and len(out):
+                tb = get_tb(sim, which=TBResistant)
+                out = out[tb.active_tb[out]]
             if exclude_on_treatment and len(out):
                 tb = get_tb(sim, which=TBResistant)
                 out = out[tb.state[out] != TBS.TREATMENT]

--- a/tbsim/resistance/treatments.py
+++ b/tbsim/resistance/treatments.py
@@ -295,8 +295,6 @@ class TxDeliveryR(ss.Intervention):
                     if other is not None and len(switching):
                         other.interrupt(switching)
             start = start[tb.state[start] != TBS.TREATMENT]
-            # Safety gate: treatment initiation requires current active TB regardless of eligibility source.
-            start = start[tb.active_tb[start]]
         else:
             asy = tb.asymptomatic.uids
             sym = tb.symptomatic.uids

--- a/tbsim/resistance/treatments.py
+++ b/tbsim/resistance/treatments.py
@@ -295,6 +295,8 @@ class TxDeliveryR(ss.Intervention):
                     if other is not None and len(switching):
                         other.interrupt(switching)
             start = start[tb.state[start] != TBS.TREATMENT]
+            # Safety gate: treatment initiation requires current active TB regardless of eligibility source.
+            start = start[tb.active_tb[start]]
         else:
             asy = tb.asymptomatic.uids
             sym = tb.symptomatic.uids

--- a/tests/test_resistance.py
+++ b/tests/test_resistance.py
@@ -303,6 +303,40 @@ def test_dst_routed_treatment_does_not_start_on_cleared():
     assert tx._n_treated == len(active)
 
 
+def test_treat_latent_modes_diverge():
+    """Latent agents selected via eligibility are cleared (treat_latent=False) or run a course (treat_latent=True).
+
+    Regression guard: initiation must not strip latent (INFECTION) agents before the treat_latent
+    branch runs, otherwise both modes silently become no-ops for latent-targeted eligibility.
+    """
+    def run(treat_latent):
+        tb = tbsim.TBResistant(drugs=['RIF'], init_prev=ss.bernoulli(0.0))
+        tx = tbsim.TxDeliveryR(
+            name='tx',
+            eligibility=lambda sim: sim.get_tb().latent.uids,
+            product=tbsim.TxR(strains=tb.strains, base_efficacy=0.0, adherence=1.0),
+            treat_latent=treat_latent,
+        )
+        sim = make_sim(tb, n=200, interventions=tx)
+        sim.init()
+        tb = sim.get_tb()
+        latent = ss.uids(np.arange(100))
+        tb.state[latent] = TBS.INFECTION
+        tb.strain_mask[latent] = 1
+        sim.interventions['tx']._initiate()
+        return sim.get_tb(), sim.interventions['tx'], latent
+
+    # treat_latent=False: latent agents are cleared immediately, not counted as treated.
+    tb_f, tx_f, latent = run(False)
+    assert tx_f._n_treated == 0
+    assert (tb_f.state[latent] == TBS.CLEARED).all()
+
+    # treat_latent=True: latent agents run a full course (state -> TREATMENT, counted as treated).
+    tb_t, tx_t, latent = run(True)
+    assert tx_t._n_treated == len(latent)
+    assert (tb_t.state[latent] == TBS.TREATMENT).all()
+
+
 # --------------------------------------------------------------------------- explicit efficacy vector / adherence distribution / retreatment classifier
 def test_treatment_explicit_efficacy_vector():
     """TxR(efficacy_by_strain=...) uses the given per-strain vector T_l verbatim as the cure probabilities

--- a/tests/test_resistance.py
+++ b/tests/test_resistance.py
@@ -270,10 +270,37 @@ def test_dst_router_matches_observed_profile():
     dstd.dst_profile[rif_only] = 0b01   # observed RIF-resistant (bit 0 = RIF)
     dstd.dst_profile[both] = 0b11       # RIF + BDQ
     dstd.dst_profile[sus] = 0b00
-    any_rif = set(dstd.matches(RIF=True)(sim))
-    rif_not_bdq = set(dstd.matches(RIF=True, BDQ=False)(sim))
+    any_rif = set(dstd.matches(RIF=True, require_active_tb=False)(sim))
+    rif_not_bdq = set(dstd.matches(RIF=True, BDQ=False, require_active_tb=False)(sim))
     assert any_rif == set(rif_only) | set(both)   # all observed RIF-resistant
     assert rif_not_bdq == set(rif_only)           # RIF-resistant, BDQ-susceptible only
+
+
+def test_dst_routed_treatment_does_not_start_on_cleared():
+    """DST-routed treatment initiation should not start courses for CLEARED agents."""
+    tb = tbsim.TBResistant(drugs=['RIF'], init_prev=ss.bernoulli(0.0))
+    dst = tbsim.DSTDelivery(name='dst', product=tbsim.DST(strains=tb.strains))
+    tx = tbsim.TxDeliveryR(
+        name='tx',
+        eligibility=dst.matches(RIF=True),
+        product=tbsim.TxR(strains=tb.strains, base_efficacy=0.8, regimen_drugs=['RIF']),
+    )
+    sim = make_sim(tb, n=300, interventions=[dst, tx])
+    sim.init()
+    tb = sim.get_tb()
+    tx = sim.interventions['tx']
+    dstd = sim.interventions['dst']
+    all_uids = ss.uids(np.arange(300))
+    # Everyone has a tested positive DST profile.
+    dstd.dst_tested[all_uids] = True
+    dstd.dst_profile[all_uids] = 0b1
+    active = ss.uids(np.arange(150))
+    cleared = ss.uids(np.arange(150, 300))
+    tb.state[active] = TBS.SYMPTOMATIC
+    tb.state[cleared] = TBS.CLEARED
+    tx._initiate()
+    # Only active TB agents should be started.
+    assert tx._n_treated == len(active)
 
 
 # --------------------------------------------------------------------------- explicit efficacy vector / adherence distribution / retreatment classifier


### PR DESCRIPTION
*Notes from Claude on the Codex-proposed changes:*

Kept the DST fix, reverted the treatment-initiation gate, and added CI coverage for the feature it was breaking.

✅ Kept

- dst.py: require_active_tb=True on matches() / observed_resistant(). This is the real fix. DST profiles are durable, so a resistant profile persists after an agent clears TB — dst.matches(RIF=True) was routing already-CLEARED agents into treatment. Gating on current active TB (with an opt-out) is correct.
- Both test changes for it — the require_active_tb=False update to test_dst_router_matches_observed_profile and the new test_dst_routed_treatment_does_not_start_on_cleared. Confirmed the new test passes on the dst.py fix alone.
- The two high_gap_* demo scripts (untouched).

❌ Reverted

- treatments.py: the start = start[tb.active_tb[start]] "safety gate" in _initiate. It was both redundant and a silent regression:
  - Redundant — for the DST-routing case it targeted, matches()/observed_resistant() already gate on active TB after the dst.py change.
  - Regression — it stripped all non-active-TB agents (incl. latent INFECTION) from start before the treat_latent block at lines 317–331. Since latent agents only ever reach treatment via the eligibility branch, this made the entire treat_latent feature dead code. Both modes collapsed to no-ops (high_gap_02: parent 0 vs 2961 treated → HEAD 0 vs 0, latent left untouched). CI didn't catch it because nothing exercised treat_latent.

➕ Added

- test_treat_latent_modes_diverge — asserts treat_latent=False clears latent-targeted agents (_n_treated==0, state→CLEARED) and treat_latent=True runs a course (_n_treated==N, state→TREATMENT). Verified it fails if the gate is reintroduced.

If a defensive gate is still wanted, it should sit after the treat_latent block and exclude only genuinely invalid targets (CLEARED/DEAD/SUSCEPTIBLE), not "not active_tb".

cc @menriquez-IDM 