### PR TITLE
This PR is a validation (and updates) for PR 441 

### DIFF
--- a/tbsim/resistance/docs/tbsim-resistance-user-manual.md
+++ b/tbsim/resistance/docs/tbsim-resistance-user-manual.md
@@ -663,7 +663,7 @@ These are specified or desired but **not fully implemented** yet. Acceptance cri
 |-------|------------------|
 | DST indeterminate | Binary observed profile only (no explicit indeterminate outcome) |
 | TPT partial efficacy | Sterilization is all-or-nothing per strain; no per-drug TPT `resist_penalty` |
-| Time-varying progression hazard | `ti_infected` resets on exposure; full time-varying hazard not modeled |
+| Time-varying progression hazard | Optional exponential decline is modeled via `k_asy`/`k_non` (defaults 0 = constant hazard); `ti_infected` resets on exposure |
 | LTFU outcome | Not a separate treatment outcome |
 
 ---

--- a/tbsim/resistance/tb_resistant.py
+++ b/tbsim/resistance/tb_resistant.py
@@ -79,6 +79,13 @@ class TBResistant(TB):
         )
         self.update_pars(pars, **kwargs)
 
+        # TB validates these in its init, but TBResistant applies pars after super().__init__.
+        # Re-validate here so negative shape parameters are consistently rejected.
+        if self.pars.k_asy < 0:
+            raise ValueError(f'k_asy must be >= 0, got {self.pars.k_asy}')
+        if self.pars.k_non < 0:
+            raise ValueError(f'k_non must be >= 0, got {self.pars.k_non}')
+
         # Spec default coupling: σ_L defaults to rr_reinfection_rec, σ_N to σ_L. Users (or the ODE
         # null) override explicitly, e.g. rr_reinfection_inf=1.0.
         if self.pars.rr_reinfection_inf is None:
@@ -284,10 +291,11 @@ class TBResistant(TB):
             multi = m.carried(self.strain_mask[u]).sum(1) >= 2
             psi = np.where(multi, p.rr_prog_super, 1.0)
             omega = np.where(multi, p.rr_clear_super, 1.0)
+            inf_non, inf_asy = self.progression_rates(u)
             self.transition(u, to={
                 TBS.CLEARED:        p.inf_cle * omega,
-                TBS.NON_INFECTIOUS: p.inf_non * self.rr_activation[u],
-                TBS.ASYMPTOMATIC:   p.inf_asy * self.rr_activation[u] * psi,
+                TBS.NON_INFECTIOUS: inf_non,
+                TBS.ASYMPTOMATIC:   inf_asy * psi,
             }, rng=self._rng_inf)
             dest = self.state[u]
             cleared = u[dest == TBS.CLEARED]

--- a/tbsim/tb.py
+++ b/tbsim/tb.py
@@ -177,6 +177,12 @@ class TB(BaseTB):
         )
         self.update_pars(pars, **kwargs)
 
+        # Decline parameters are shape terms for exp(-k*tau); require k >= 0.
+        if self.pars.k_asy < 0:
+            raise ValueError(f'k_asy must be >= 0, got {self.pars.k_asy}')
+        if self.pars.k_non < 0:
+            raise ValueError(f'k_non must be >= 0, got {self.pars.k_non}')
+
         # CRN-safe RNG distributions for per-step transition draws (one per source state)
         self._rng_inf = ss.random(name='tb_rng_inf')   # INFECTION exits
         self._rng_non = ss.random(name='tb_rng_non')   # NON_INFECTIOUS exits

--- a/tbsim_examples/run_time_varying_progression.py
+++ b/tbsim_examples/run_time_varying_progression.py
@@ -1,0 +1,186 @@
+"""
+Time-varying progression example for developers.
+
+Why this update exists
+- Time-varying progression is needed to represent front-loaded progression after infection.
+- The default model remains constant-hazard (k_asy=0, k_non=0) for backward compatibility.
+- TBResistant now uses the same time-varying progression-rate pathway as TB in latent exits.
+
+What this script demonstrates
+1) Case A (default): constant progression hazards (k_asy=0, k_non=0)
+2) Case B: front-loaded progression (k_asy=6)
+3) Side-by-side results for both TB and TBResistant
+4) Overlay against Ferebee/Sutherland reference points
+
+What this script does not do
+- It does not assert correctness/validation checks at runtime.
+- Those checks live in automated tests under tests/.
+
+Design notes
+- Closed cohort (no transmission, networks, demographics) so time-since-infection equals sim time.
+- ASYMPTOMATIC is made absorbing to make the "ever reached ASYMPTOMATIC" curve explicit.
+"""
+
+from pathlib import Path
+import argparse
+
+import matplotlib.pyplot as plt
+import numpy as np
+import starsim as ss
+import tbsim
+
+
+# Empirical progression anchors (cumulative ever-active by year since infection, %)
+FEREBEE = {1: 4.6, 2: 4.8, 3: 5.2, 5: 5.7, 10: 6.2}
+SUTHERLAND = {1: 5.8, 2: 8.0, 3: 8.8, 5: 9.3, 10: 9.6}
+
+DEVELOPER_NOTES = [
+    "Default behavior remains constant-hazard (k_asy=0, k_non=0).",
+    "Front-loading is opt-in via k_asy>0 (and optional k_non>0).",
+    "Validation checks moved to tests: tests/test_time_varying.py and tests/test_resistance.py.",
+]
+
+
+def make_closed_cohort(tb_model, n_agents=12000, years=10, seed=1):
+    """Build a closed-cohort sim where everyone starts in INFECTION."""
+    sim = tbsim.Sim(
+        tb_model=tb_model,
+        n_agents=n_agents,
+        networks=[],
+        demographics=[],
+        dt=ss.days(30),
+        start=ss.date("2000-01-01"),
+        stop=ss.date(f"{2000 + years}-01-01"),
+        rand_seed=seed,
+    )
+    sim.pars.verbose = 0
+    return sim
+
+
+def run_curve(tb_model, n_agents=12000, years=10, seed=1):
+    """Run sim and return time axis (years) and ever-ASY curve proxy."""
+    sim = make_closed_cohort(tb_model=tb_model, n_agents=n_agents, years=years, seed=seed)
+    sim.run()
+    tb = sim.get_tb()
+
+    n0 = sum(int(tb.results[f"n_{state.name}"][0]) for state in tbsim.TBS)
+    curve = np.asarray(tb.results["n_ASYMPTOMATIC"][:], dtype=float) / n0
+    years_since_infection = np.arange(len(curve)) * sim.t.dt_year
+
+    i1 = int(round(1.0 / sim.t.dt_year))
+    y1_share = float(curve[i1] / curve[-1]) if curve[-1] > 0 else np.nan
+    final_total = float(curve[-1])
+
+    return years_since_infection, curve, y1_share, final_total
+
+
+def build_tb_case(k_asy):
+    return tbsim.TB(
+        init_prev=ss.bernoulli(1.0),
+        init_prev_active=ss.bernoulli(0.0),
+        beta=ss.peryear(0.0),
+        inf_cle=ss.peryear(0.1),
+        inf_non=ss.peryear(0.0),
+        inf_asy=ss.peryear(0.3),
+        asy_non=ss.peryear(0.0),
+        asy_sym=ss.peryear(0.0),
+        k_asy=k_asy,
+    )
+
+
+def build_tbr_case(k_asy):
+    return tbsim.TBResistant(
+        pars=dict(
+            init_prev=ss.bernoulli(1.0),
+            init_prev_active=ss.bernoulli(0.0),
+            beta=ss.peryear(0.0),
+            inf_cle=ss.peryear(0.1),
+            inf_non=ss.peryear(0.0),
+            inf_asy=ss.peryear(0.3),
+            asy_non=ss.peryear(0.0),
+            asy_sym=ss.peryear(0.0),
+            k_asy=k_asy,
+        )
+    )
+
+
+def make_plot(tb_const, tb_front, tbr_const, tbr_front, outpath):
+    yrs_tb, curve_tb_const, share_tb_const, total_tb_const = tb_const
+    _, curve_tb_front, share_tb_front, total_tb_front = tb_front
+
+    yrs_tbr, curve_tbr_const, share_tbr_const, total_tbr_const = tbr_const
+    _, curve_tbr_front, share_tbr_front, total_tbr_front = tbr_front
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4.8), constrained_layout=False)
+
+    axes[0].plot(yrs_tb, 100 * curve_tb_const, lw=2, label="TB constant (default k_asy=0)")
+    axes[0].plot(yrs_tb, 100 * curve_tb_front, lw=2, label="TB front-loaded (k_asy=6)")
+    axes[0].plot(list(FEREBEE.keys()), list(FEREBEE.values()), 'ko', ms=6, label='Ferebee 1970')
+    axes[0].plot(list(SUTHERLAND.keys()), list(SUTHERLAND.values()), 'ks', ms=6, mfc='white', mew=1.2, label='Sutherland 1968')
+    axes[0].set_title("TB: ever reached ASYMPTOMATIC")
+    axes[0].set_xlabel("Years since infection")
+    axes[0].set_ylabel("Cumulative (%)")
+    axes[0].grid(alpha=0.25)
+    axes[0].legend(loc="center left", bbox_to_anchor=(1.02, 0.5), borderaxespad=0.0)
+    axes[0].set_xlim(0, 10.5)
+
+    axes[1].plot(yrs_tbr, 100 * curve_tbr_const, lw=2, label="TBResistant constant (default k_asy=0)")
+    axes[1].plot(yrs_tbr, 100 * curve_tbr_front, lw=2, label="TBResistant front-loaded (k_asy=6)")
+    axes[1].plot(list(FEREBEE.keys()), list(FEREBEE.values()), 'ko', ms=6, label='Ferebee 1970')
+    axes[1].plot(list(SUTHERLAND.keys()), list(SUTHERLAND.values()), 'ks', ms=6, mfc='white', mew=1.2, label='Sutherland 1968')
+    axes[1].set_title("TBResistant: ever reached ASYMPTOMATIC")
+    axes[1].set_xlabel("Years since infection")
+    axes[1].set_ylabel("Cumulative (%)")
+    axes[1].grid(alpha=0.25)
+    axes[1].legend(loc="center left", bbox_to_anchor=(1.02, 0.5), borderaxespad=0.0)
+    axes[1].set_xlim(0, 10.5)
+
+    fig.suptitle(
+        "Time-varying progression comparison\n"
+        f"TB year-1 share: {share_tb_const:.3f} -> {share_tb_front:.3f}, total: {100*total_tb_const:.2f}% -> {100*total_tb_front:.2f}% | "
+        f"TBResistant year-1 share: {share_tbr_const:.3f} -> {share_tbr_front:.3f}, total: {100*total_tbr_const:.2f}% -> {100*total_tbr_front:.2f}%",
+        fontsize=10,
+    )
+
+    # Reserve space on the right for outside legends
+    fig.subplots_adjust(right=0.78, wspace=0.35)
+    fig.savefig(outpath, dpi=160, bbox_inches='tight')
+    return fig
+
+
+def main(show=False):
+    print("Running time-varying progression developer example...")
+    print("Case A: constant hazards (default, k_asy=0)")
+    print("Case B: front-loaded hazards (k_asy=6)")
+    print("\nDeveloper notes:")
+    for note in DEVELOPER_NOTES:
+        print(f"- {note}")
+
+    tb_const_model = build_tb_case(k_asy=0.0)
+    tb_front_model = build_tb_case(k_asy=6.0)
+    tbr_const_model = build_tbr_case(k_asy=0.0)
+    tbr_front_model = build_tbr_case(k_asy=6.0)
+
+    tb_const = run_curve(tb_const_model, seed=11)
+    tb_front = run_curve(tb_front_model, seed=11)
+
+    tbr_const = run_curve(tbr_const_model, seed=11)
+    tbr_front = run_curve(tbr_front_model, seed=11)
+
+    outpath = Path(__file__).with_name("time_varying_progression_comparison.png")
+    fig = make_plot(tb_const, tb_front, tbr_const, tbr_front, outpath)
+    print(f"\nSaved plot: {outpath}")
+
+
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run TB/TBResistant time-varying progression example')
+    parser.add_argument('--show', action='store_true', help='Display plot window in addition to saving PNG')
+    args = parser.parse_args()
+    main(show=args.show)

--- a/tbsim_examples/run_time_varying_progression.py
+++ b/tbsim_examples/run_time_varying_progression.py
@@ -111,28 +111,26 @@ def make_plot(tb_const, tb_front, tbr_const, tbr_front, outpath):
     yrs_tbr, curve_tbr_const, share_tbr_const, total_tbr_const = tbr_const
     _, curve_tbr_front, share_tbr_front, total_tbr_front = tbr_front
 
-    fig, axes = plt.subplots(1, 2, figsize=(12, 4.8), constrained_layout=False)
+    fig, axes = plt.subplots(1, 2, figsize=(12.8, 5.2), constrained_layout=False)
 
-    axes[0].plot(yrs_tb, 100 * curve_tb_const, lw=2, label="TB constant (default k_asy=0)")
-    axes[0].plot(yrs_tb, 100 * curve_tb_front, lw=2, label="TB front-loaded (k_asy=6)")
-    axes[0].plot(list(FEREBEE.keys()), list(FEREBEE.values()), 'ko', ms=6, label='Ferebee 1970')
-    axes[0].plot(list(SUTHERLAND.keys()), list(SUTHERLAND.values()), 'ks', ms=6, mfc='white', mew=1.2, label='Sutherland 1968')
+    l_const0, = axes[0].plot(yrs_tb, 100 * curve_tb_const, lw=2, label="Constant (k_asy=0)")
+    l_front0, = axes[0].plot(yrs_tb, 100 * curve_tb_front, lw=2, label="Front-loaded (k_asy=6)")
+    l_ferebee0, = axes[0].plot(list(FEREBEE.keys()), list(FEREBEE.values()), 'ko', ms=6, label='Ferebee 1970')
+    l_suth0, = axes[0].plot(list(SUTHERLAND.keys()), list(SUTHERLAND.values()), 'ks', ms=6, mfc='white', mew=1.2, label='Sutherland 1968')
     axes[0].set_title("TB: ever reached ASYMPTOMATIC")
     axes[0].set_xlabel("Years since infection")
     axes[0].set_ylabel("Cumulative (%)")
     axes[0].grid(alpha=0.25)
-    axes[0].legend(loc="center left", bbox_to_anchor=(1.02, 0.5), borderaxespad=0.0)
     axes[0].set_xlim(0, 10.5)
 
-    axes[1].plot(yrs_tbr, 100 * curve_tbr_const, lw=2, label="TBResistant constant (default k_asy=0)")
-    axes[1].plot(yrs_tbr, 100 * curve_tbr_front, lw=2, label="TBResistant front-loaded (k_asy=6)")
-    axes[1].plot(list(FEREBEE.keys()), list(FEREBEE.values()), 'ko', ms=6, label='Ferebee 1970')
-    axes[1].plot(list(SUTHERLAND.keys()), list(SUTHERLAND.values()), 'ks', ms=6, mfc='white', mew=1.2, label='Sutherland 1968')
+    axes[1].plot(yrs_tbr, 100 * curve_tbr_const, lw=2)
+    axes[1].plot(yrs_tbr, 100 * curve_tbr_front, lw=2)
+    axes[1].plot(list(FEREBEE.keys()), list(FEREBEE.values()), 'ko', ms=6)
+    axes[1].plot(list(SUTHERLAND.keys()), list(SUTHERLAND.values()), 'ks', ms=6, mfc='white', mew=1.2)
     axes[1].set_title("TBResistant: ever reached ASYMPTOMATIC")
     axes[1].set_xlabel("Years since infection")
-    axes[1].set_ylabel("Cumulative (%)")
+    axes[1].set_ylabel("")
     axes[1].grid(alpha=0.25)
-    axes[1].legend(loc="center left", bbox_to_anchor=(1.02, 0.5), borderaxespad=0.0)
     axes[1].set_xlim(0, 10.5)
 
     fig.suptitle(
@@ -140,10 +138,21 @@ def make_plot(tb_const, tb_front, tbr_const, tbr_front, outpath):
         f"TB year-1 share: {share_tb_const:.3f} -> {share_tb_front:.3f}, total: {100*total_tb_const:.2f}% -> {100*total_tb_front:.2f}% | "
         f"TBResistant year-1 share: {share_tbr_const:.3f} -> {share_tbr_front:.3f}, total: {100*total_tbr_const:.2f}% -> {100*total_tbr_front:.2f}%",
         fontsize=10,
+        y=0.98,
     )
 
-    # Reserve space on the right for outside legends
-    fig.subplots_adjust(right=0.78, wspace=0.35)
+    # Shared legend outside the plotting area (bottom-center)
+    fig.legend(
+        [l_const0, l_front0, l_ferebee0, l_suth0],
+        ["Constant (k_asy=0)", "Front-loaded (k_asy=6)", "Ferebee 1970", "Sutherland 1968"],
+        loc='lower center',
+        ncol=4,
+        frameon=False,
+        bbox_to_anchor=(0.5, 0.02),
+    )
+
+    # Reserve space for suptitle (top) and shared legend (bottom)
+    fig.subplots_adjust(top=0.78, bottom=0.22, wspace=0.35)
     fig.savefig(outpath, dpi=160, bbox_inches='tight')
     return fig
 

--- a/tests/test_resistance.py
+++ b/tests/test_resistance.py
@@ -114,6 +114,83 @@ def test_superinfection_requires_sigma():
     assert np.sum(on.results.tb['new_identical_superinf']) > 0  # identical-strain re-exposures now counted (spec §1)
 
 
+# --------------------------------------------------------------------------- time-varying progression
+def _run_resistance_ever_asy_curve(k_asy=0.0, k_non=0.0, n=12_000, years=10, seed=1):
+    """Closed latent cohort for TVP checks; ASYMPTOMATIC is absorbing so n_ASYMPTOMATIC is ever-ASY."""
+    tb = tbsim.TBResistant(
+        pars=dict(
+            init_prev=ss.bernoulli(1.0),
+            init_prev_active=ss.bernoulli(0.0),
+            beta=ss.peryear(0.0),
+            inf_cle=ss.peryear(0.1),
+            inf_non=ss.peryear(0.0),
+            inf_asy=ss.peryear(0.3),
+            asy_non=ss.peryear(0.0),
+            asy_sym=ss.peryear(0.0),
+            k_asy=k_asy,
+            k_non=k_non,
+        )
+    )
+    sim = tbsim.Sim(
+        tb_model=tb, n_agents=n, networks=[], demographics=[], dt=ss.days(30),
+        start=ss.date('2000-01-01'), stop=ss.date(f'{2000 + years}-01-01'), rand_seed=seed,
+    )
+    sim.pars.verbose = 0
+    sim.run()
+    curve = np.asarray(sim.get_tb().results['n_ASYMPTOMATIC'][:], dtype=float) / n
+    return curve, sim.t.dt_year
+
+
+def test_resistance_k_asy_front_loads_progression():
+    """TBResistant should honor k_asy: year-1 share rises and eventual direct progression falls."""
+    curve0, dt_year = _run_resistance_ever_asy_curve(k_asy=0.0)
+    curveK, _ = _run_resistance_ever_asy_curve(k_asy=6.0)
+
+    i1 = int(round(1.0 / dt_year))
+    frac0 = curve0[i1] / curve0[-1]
+    fracK = curveK[i1] / curveK[-1]
+
+    assert np.isclose(curveK[0], curve0[0])
+    assert np.all(np.diff(curveK) >= -1e-12)
+    assert fracK > frac0 + 0.25
+    assert fracK > 0.85 and frac0 < 0.55
+    assert curveK[-1] < 0.5 * curve0[-1]
+
+
+def test_resistance_k_zero_matches_default_closed_cohort():
+    """Explicit k_asy=k_non=0 is identical to defaults for TBResistant."""
+    def run(**pars):
+        tb = tbsim.TBResistant(
+            pars=dict(
+                init_prev=ss.bernoulli(1.0),
+                init_prev_active=ss.bernoulli(0.0),
+                beta=ss.peryear(0.0),
+            ) | pars
+        )
+        sim = tbsim.Sim(
+            tb_model=tb, n_agents=2_000, networks=[], demographics=[], dt=ss.days(30),
+            start=ss.date('2000-01-01'), stop=ss.date('2005-01-01'), rand_seed=7,
+        )
+        sim.pars.verbose = 0
+        sim.run()
+        return sim.get_tb()
+
+    tb0 = run()
+    tb1 = run(k_asy=0.0, k_non=0.0)
+    for state in TBS:
+        np.testing.assert_array_equal(tb0.results[f'n_{state.name}'][:], tb1.results[f'n_{state.name}'][:])
+    np.testing.assert_array_equal(tb0.results['cum_active'][:], tb1.results['cum_active'][:])
+    np.testing.assert_array_equal(tb0.results['new_deaths'][:], tb1.results['new_deaths'][:])
+
+
+def test_resistance_negative_k_rejected():
+    """TBResistant inherits non-negative validation for TVP shape parameters."""
+    with pytest.raises(ValueError, match='k_asy must be >= 0'):
+        tbsim.TBResistant(pars=dict(k_asy=-1.0))
+    with pytest.raises(ValueError, match='k_non must be >= 0'):
+        tbsim.TBResistant(pars=dict(k_non=-0.5))
+
+
 # --------------------------------------------------------------------------- de-novo acquisition
 def test_denovo_mixed_vs_replacement():
     """De-novo resistance from a pure-A epidemic: mixed makes AB, replacement does not; no p_rand makes none."""

--- a/tests/test_time_varying.py
+++ b/tests/test_time_varying.py
@@ -60,6 +60,14 @@ def test_decline_params_default_off():
     assert float(tb.pars.k_non) == 0.0
 
 
+def test_negative_k_rejected_in_tb():
+    """Shape parameters must be non-negative."""
+    with pytest.raises(ValueError, match='k_asy must be >= 0'):
+        tbsim.TB(k_asy=-1.0)
+    with pytest.raises(ValueError, match='k_non must be >= 0'):
+        tbsim.TB(k_non=-0.5)
+
+
 # --- progression_rates: the exact spec formula ---
 
 def _setup_latent(sim, uids, taus, rr=1.0):


### PR DESCRIPTION
Validation and fixes branch for PR 441:

We implemented time-varying progression in both TB and TBResistant paths.

- Main fix: TBResistant latent transitions now use the same progression-rate pathway as TB, so k_asy/k_non actually affect INFECTION exits in resistance runs.
- We also closed a validation gap: negative k values are now rejected consistently (TB + TBResistant).

Quality checks completed:

- Added regression tests for:
- Front-loading behavior when k_asy > 0
- Backward compatibility when k_asy=k_non=0
- Negative-k rejection
- Targeted test runs are passing.

Example:

- Constant default vs front-loaded case comparison
- TB and TBResistant side-by-side
- Ferebee/Sutherland data-point overlays
- Plot export for quick review

<img width="1202" height="596" alt="image" src="https://github.com/user-attachments/assets/b251341f-5882-4b29-9fbd-6c4ade71d6e9" />
