### PR TITLE
Updates for starsim v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the codebase are documented in this file.
 
+## Version 0.10.3 (2026-08-29)
+- Updated for Starsim 3.6.0, which makes `float()` on an `ss.TimePar` raise a `TypeError` (it silently discarded the unit) and records `new_infections` inside `ss.Infection.set_prognoses()` rather than inferring them from `ti_infected` afterwards.
+- **Fixed `DxDelivery(result_validity=...)`**: `step_expire_results` converted the validity window with `float(self.result_validity)`, which now raises. It divides by the module's own `dt` instead (`self.result_validity / self.t.dt`), matching `DSTDelivery._expire_stale`.
+- **Fixed the LSHTM reference ODE** (`tbsim.compartmental.TB_SS`): its Euler step took `float(self.dt)` for a timestep in years, which now raises; it uses `self.dt.years` explicitly.
+- **Fixed silently-zero incidence results for `TBResistant`**: `TBResistant.set_prognoses` overrode the base method without calling `super()`, so under Starsim 3.6.0 its `new_infections` and `cum_infections` results stayed zero for the whole run (under 3.5.x the base class recomputed them afterwards, hiding the omission). Added a regression test.
+- Raised minimum Starsim dependency to `>=3.6.0`.
+
 ## Version 0.10.2 (2026-07-20)
 - Reworked several multi-strain / drug-resistance behaviors (`tbsim.resistance`) and lifted latent reinfection into base `TB`.
 - **Latent reinfection in base `TB`**: `rr_reinfection_inf` (σ_L) and `rr_reinfection_non` (σ_N) are now base-`TB` parameters, so latent (`INFECTION`) and non-infectious (`NON_INFECTIOUS`) agents are reinfection-eligible in single-strain models too. A re-exposure resets the `ti_infected` clock without otherwise changing the agent's state (clock reset only). σ_L defaults to `rr_reinfection_rec` and σ_N to σ_L; set them to `0` to disable.

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -233,7 +233,7 @@ interlinks:
     matplotlib:
       url: https://matplotlib.org/stable/
     sciris:
-      url: https://docs.sciris.org/en/latest/
+      url: https://docs.sciris.org/
     starsim:
       url: https://docs.starsim.org/
   autolink: true

--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,2 +1,2 @@
-version: 0.10.2
-versiondate: '2026-07-20'
+version: 0.10.3
+versiondate: '2026-08-29'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "networkx",
   "matplotlib",
   "seaborn",
-  "starsim>=3.5.1",
+  "starsim>=3.6.0",
 ]
 
 [project.optional-dependencies]

--- a/tbsim/compartmental/lshtm_ode.py
+++ b/tbsim/compartmental/lshtm_ode.py
@@ -231,7 +231,7 @@ class TB_SS(ss.Module):
         """Euler integration of the ODE system."""
         p = self.pars
         c = self.c
-        dt = float(self.dt)  # hard-coded in years
+        dt = self.dt.years  # rates in pars are per-year, so integrate in years
 
         foi = (p.beta / p.N) * (p.trans_asymp * c.ASYMPTOMATIC + c.SYMPTOMATIC)
 

--- a/tbsim/interventions/diagnostics.py
+++ b/tbsim/interventions/diagnostics.py
@@ -224,8 +224,8 @@ class DxDelivery(ss.Intervention):
         if len(positive_uids) == 0:
             return
 
-        # Convert validity from days to timesteps
-        validity_steps = float(self.result_validity) / self.sim.t.dt.days
+        # Convert validity to timesteps
+        validity_steps = self.result_validity / self.t.dt
         ti_set = self.ti_result_set[positive_uids]
         expired = positive_uids[~np.isnan(ti_set) & (self.ti >= ti_set + validity_steps)]
         if len(expired) > 0:

--- a/tbsim/resistance/tb_resistant.py
+++ b/tbsim/resistance/tb_resistant.py
@@ -264,6 +264,7 @@ class TBResistant(TB):
         (entering ``INFECTION`` from a susceptible state, or keeping the current state for a
         superinfection) at count 1, regardless of how many copies the source carried.
         """
+        super().set_prognoses(uids, sources)  # Record the new infections; also clears `susceptible`
         if len(uids) == 0:
             return
         ti = self.ti

--- a/tbsim/version.py
+++ b/tbsim/version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__ = '0.10.2'
-__versiondate__ = '2026-07-20'
+__version__ = '0.10.3'
+__versiondate__ = '2026-08-29'
 __license__ = f'TBsim {__version__} ({__versiondate__}) — © 2023-2026 by IDM'

--- a/tbsim_examples/run_malnutrition.py
+++ b/tbsim_examples/run_malnutrition.py
@@ -29,14 +29,14 @@ def make_tb_nut():
         n_agents=1000,
         start=1980,
         stop=1995,
-        dt=float(ss.days(7))/365,
+        dt=ss.days(7),
         beta=0.01,
         init_prev=0.25,
         diseases=[nut],
         demographics=[ss.Pregnancy(pars=dict(fertility_rate=15)), ss.Deaths(pars=dict(death_rate=10))],
         connectors=connector,
     )
-    sim.pars.verbose = float(sim.pars.dt) / 5
+    sim.pars.verbose = sim.pars.dt.years / 5
     return sim
 
 

--- a/tests/test_resistance.py
+++ b/tests/test_resistance.py
@@ -784,6 +784,21 @@ def test_dst_retreat_after_guard_bounds_treatments():
     assert unguarded > 2 * guarded  # continuous retreatment inflates the unguarded count
 
 
+def test_incidence_results_are_recorded():
+    """TBResistant records new/cum infections and incidence like base TB.
+
+    Regression test: `set_prognoses` must call `super()`, since Starsim v3.6.0 counts infections
+    as they happen rather than inferring them from `ti_infected` afterwards. Without the call,
+    `new_infections` and `cum_infections` stay silently zero for the whole run.
+    """
+    tb = tbsim.TBResistant(init_prev=ss.bernoulli(0.02))
+    sim = make_sim(tb, seed=0, n=1000, stop='2010-12-31')
+    sim.run()
+    res = sim.results[tb.name]
+    assert res.new_infections.sum() > 0
+    assert res.cum_infections[-1] == res.new_infections.sum()
+
+
 if __name__ == '__main__':
     import sys
     sys.exit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
Two fixes:
- `float(timepar)` is now an error in Starsim, since it's ambiguous; usually `timepar.years` is what was meant instead.
- `set_prognoses()` does incidence counting now, so it's called where it wasn't before.